### PR TITLE
feat: editor and admin roles (RBAC por programa)

### DIFF
--- a/docs/es/content-management.md
+++ b/docs/es/content-management.md
@@ -6,6 +6,7 @@ El sitio usa **Supabase** como única fuente de verdad en runtime. Páginas, pro
 
 - **Sitio público:** `PublicContentProvider` carga `content_items`, traducciones y `site_editorial` al iniciar.
 - **Editor:** login en `/editor-login` con usuario Supabase Auth; guardar/publicar hace upsert en DB (sin redeploy).
+- **Roles:** `admin` (todo el sitio) y `editor` (un solo programa). Perfiles en `editor_profiles`; panel de usuarios en `/admin/usuarios` (solo admin).
 - **Import / disaster recovery:** `npm run seed:supabase` lee JSON de respaldo en `scripts/backup-json/` (no archivos servidos por la app).
 
 ## Tablas principales
@@ -28,6 +29,14 @@ npm run seed:supabase:dry
 ```
 
 Copias de respaldo: `scripts/backup-json/contentIndex.json`, `scripts/backup-json/editor/home-about-contact.json`, `scripts/backup-json/episodes/*.json`.
+
+### Migración obligatoria: roles editor / admin
+
+Ejecutar **una vez** en el SQL Editor de Supabase: [`scripts/supabase-editor-roles-migration.sql`](../../scripts/supabase-editor-roles-migration.sql).
+
+- Crea `editor_profiles` y políticas RLS por programa.
+- Los usuarios ya existentes en Auth pasan a `admin` automáticamente.
+- Crear editores nuevos: `/admin/usuarios` (requiere `SUPABASE_SERVICE_ROLE_KEY` en Functions).
 
 ### Migración obligatoria: `content_kind`
 

--- a/functions/__dev/editor/[[path]].ts
+++ b/functions/__dev/editor/[[path]].ts
@@ -1,4 +1,5 @@
-import { assertSupabaseJwtAuthorized, jsonResponse } from '../../_shared/supabaseJwtAuth';
+import { assertEditorAuthorized } from '../../_shared/editorAuth';
+import { jsonResponse } from '../../_shared/supabaseJwtAuth';
 import { handleEditorRoute } from '../../_shared/editor/handlers';
 
 interface Env {
@@ -19,8 +20,11 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   const { request, env, params } = context;
   const subpath = Array.isArray(params.path) ? params.path.join('/') : String(params.path ?? '');
 
-  const authError = await assertSupabaseJwtAuthorized(request, env);
-  if (authError) return authError;
+  const subpathForAuth = Array.isArray(params.path) ? params.path.join('/') : String(params.path ?? '');
+  const authResult = await assertEditorAuthorized(request, env, {
+    requireAdmin: subpathForAuth.startsWith('admin/'),
+  });
+  if ('error' in authResult) return authResult.error;
 
   const isAudioProxy = request.method === 'POST' && subpath === 'upload-episode-audio-proxy';
   let body: unknown = {};
@@ -59,8 +63,10 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     },
     supabaseEnv: {
       SUPABASE_URL: env.SUPABASE_URL,
+      SUPABASE_ANON_KEY: env.SUPABASE_ANON_KEY,
       SUPABASE_SERVICE_ROLE_KEY: env.SUPABASE_SERVICE_ROLE_KEY,
     },
+    authProfile: authResult.profile,
   });
 
   return jsonResponse(result.status, result.body);

--- a/functions/_shared/editor/adminHandlers.ts
+++ b/functions/_shared/editor/adminHandlers.ts
@@ -1,0 +1,212 @@
+import type { EditorAuthProfile, SupabaseAuthEnv } from '../editorAuth';
+import type { EditorHandlerResult } from './handlers';
+
+const fail = (message: string, status = 400): EditorHandlerResult => ({
+  status,
+  body: { ok: false, message },
+});
+
+const ok = (body: Record<string, unknown>): EditorHandlerResult => ({
+  status: 200,
+  body: { ok: true, ...body },
+});
+
+const adminHeaders = (serviceKey: string) => ({
+  Authorization: `Bearer ${serviceKey}`,
+  apikey: serviceKey,
+  'Content-Type': 'application/json',
+});
+
+const listAuthUsers = async (url: string, serviceKey: string): Promise<Map<string, string>> => {
+  const emailById = new Map<string, string>();
+  let page = 1;
+  const perPage = 200;
+
+  for (;;) {
+    const response = await fetch(
+      `${url}/auth/v1/admin/users?page=${page}&per_page=${perPage}`,
+      { headers: adminHeaders(serviceKey) }
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || 'No se pudo listar usuarios Auth.');
+    }
+    const payload = (await response.json()) as {
+      users?: Array<{ id?: string; email?: string }>;
+    };
+    const users = payload.users ?? [];
+    for (const user of users) {
+      if (user.id) emailById.set(user.id, user.email ?? '');
+    }
+    if (users.length < perPage) break;
+    page += 1;
+  }
+
+  return emailById;
+};
+
+export const handleAdminRoute = async (options: {
+  subpath: string;
+  body: Record<string, unknown>;
+  profile: EditorAuthProfile;
+  env: SupabaseAuthEnv;
+}): Promise<EditorHandlerResult> => {
+  const url = (options.env.SUPABASE_URL || '').trim();
+  const serviceKey = (options.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+  if (!url || !serviceKey) {
+    return fail('Falta SUPABASE_SERVICE_ROLE_KEY en el servidor.', 503);
+  }
+
+  if (options.profile.role !== 'admin') {
+    return fail('Solo administradores pueden realizar esta acción.', 403);
+  }
+
+  const { subpath, body } = options;
+
+  if (subpath === 'admin/list-users') {
+    try {
+      const [profilesRes, emailById] = await Promise.all([
+        fetch(`${url}/rest/v1/editor_profiles?select=user_id,role,program_id,disabled_at,created_at,updated_at&order=created_at.asc`, {
+          headers: adminHeaders(serviceKey),
+        }),
+        listAuthUsers(url, serviceKey),
+      ]);
+
+      if (!profilesRes.ok) {
+        const text = await profilesRes.text();
+        return fail(text || 'No se pudo leer editor_profiles.', 502);
+      }
+
+      const profiles = (await profilesRes.json()) as Array<Record<string, unknown>>;
+      const users = (Array.isArray(profiles) ? profiles : []).map((row) => ({
+        userId: String(row.user_id || ''),
+        email: emailById.get(String(row.user_id || '')) ?? '',
+        role: String(row.role || ''),
+        programId: row.program_id == null ? null : String(row.program_id),
+        disabledAt: row.disabled_at == null ? null : String(row.disabled_at),
+        createdAt: row.created_at == null ? null : String(row.created_at),
+        updatedAt: row.updated_at == null ? null : String(row.updated_at),
+      }));
+
+      return ok({ message: 'Usuarios cargados.', users });
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : 'Error al listar usuarios.', 502);
+    }
+  }
+
+  if (subpath === 'admin/create-user') {
+    const email = String(body.email || '').trim().toLowerCase();
+    const password = String(body.password || '');
+    const role = String(body.role || '').trim() as 'admin' | 'editor';
+    const programId = body.programId == null ? null : String(body.programId).trim();
+
+    if (!email || !password) return fail('Email y contraseña son obligatorios.');
+    if (password.length < 8) return fail('La contraseña debe tener al menos 8 caracteres.');
+    if (role !== 'admin' && role !== 'editor') return fail('Rol inválido.');
+    if (role === 'editor' && !programId) return fail('Asigná un programa al editor.');
+    if (role === 'admin' && programId) return fail('Los administradores no llevan programa asignado.');
+
+    try {
+      const createRes = await fetch(`${url}/auth/v1/admin/users`, {
+        method: 'POST',
+        headers: adminHeaders(serviceKey),
+        body: JSON.stringify({ email, password, email_confirm: true }),
+      });
+
+      if (!createRes.ok) {
+        const text = await createRes.text();
+        return fail(text || 'No se pudo crear el usuario.', 502);
+      }
+
+      const created = (await createRes.json()) as { id?: string };
+      const userId = created.id ? String(created.id) : '';
+      if (!userId) return fail('Respuesta inválida al crear usuario.', 502);
+
+      const profileRes = await fetch(`${url}/rest/v1/editor_profiles`, {
+        method: 'POST',
+        headers: { ...adminHeaders(serviceKey), Prefer: 'return=minimal' },
+        body: JSON.stringify({
+          user_id: userId,
+          role,
+          program_id: role === 'editor' ? programId : null,
+        }),
+      });
+
+      if (!profileRes.ok) {
+        await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+          method: 'DELETE',
+          headers: adminHeaders(serviceKey),
+        });
+        const text = await profileRes.text();
+        return fail(text || 'Usuario creado pero falló el perfil.', 502);
+      }
+
+      return ok({
+        message: 'Usuario creado.',
+        user: { userId, email, role, programId: role === 'editor' ? programId : null },
+      });
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : 'Error al crear usuario.', 502);
+    }
+  }
+
+  if (subpath === 'admin/update-user') {
+    const userId = String(body.userId || '').trim();
+    const role = body.role == null ? undefined : (String(body.role).trim() as 'admin' | 'editor');
+    const programId =
+      body.programId === undefined
+        ? undefined
+        : body.programId == null
+          ? null
+          : String(body.programId).trim();
+    const disabled = body.disabled;
+
+    if (!userId) return fail('userId es obligatorio.');
+    if (role !== undefined && role !== 'admin' && role !== 'editor') return fail('Rol inválido.');
+    if (role === 'editor' && programId === '') return fail('Asigná un programa al editor.');
+    if (role === 'admin' && programId) return fail('Los administradores no llevan programa asignado.');
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (role !== undefined) patch.role = role;
+    if (programId !== undefined) patch.program_id = programId;
+    if (disabled === true) patch.disabled_at = new Date().toISOString();
+    if (disabled === false) patch.disabled_at = null;
+
+    if (role === 'admin') patch.program_id = null;
+    if (role === 'editor' && programId) patch.program_id = programId;
+
+    try {
+      const updateRes = await fetch(
+        `${url}/rest/v1/editor_profiles?user_id=eq.${encodeURIComponent(userId)}`,
+        {
+          method: 'PATCH',
+          headers: { ...adminHeaders(serviceKey), Prefer: 'return=minimal' },
+          body: JSON.stringify(patch),
+        }
+      );
+
+      if (!updateRes.ok) {
+        const text = await updateRes.text();
+        return fail(text || 'No se pudo actualizar el usuario.', 502);
+      }
+
+      if (typeof body.password === 'string' && body.password.trim().length >= 8) {
+        const pwdRes = await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+          method: 'PUT',
+          headers: adminHeaders(serviceKey),
+          body: JSON.stringify({ password: String(body.password) }),
+        });
+        if (!pwdRes.ok) {
+          const text = await pwdRes.text();
+          return fail(text || 'Perfil actualizado pero falló cambiar contraseña.', 502);
+        }
+      }
+
+      return ok({ message: 'Usuario actualizado.' });
+    } catch (error) {
+      return fail(error instanceof Error ? error.message : 'Error al actualizar usuario.', 502);
+    }
+  }
+
+  return fail('Endpoint admin no encontrado.', 404);
+};

--- a/functions/_shared/editor/handlers.ts
+++ b/functions/_shared/editor/handlers.ts
@@ -8,6 +8,8 @@ import { decodeAudioBase64, decodeAudioBase64Node, buildArchiveUploadPlan, uploa
 import { parseArchiveUploadMetaFromHeaders } from './parseArchiveUploadMeta';
 import { createTranslateUsageStore } from './translateUsage';
 import type { EditorRuntimeConfig } from './types';
+import { canAccessProgram, type EditorAuthProfile } from '../editorAuth';
+import { handleAdminRoute } from './adminHandlers';
 
 export interface EditorHandlerResult {
   status: number;
@@ -32,14 +34,26 @@ export const handleEditorRoute = async (options: {
   runtime: 'local' | 'cloudflare';
   supabaseEnv?: {
     SUPABASE_URL?: string;
+    SUPABASE_ANON_KEY?: string;
     SUPABASE_SERVICE_ROLE_KEY?: string;
   };
+  authProfile?: EditorAuthProfile;
   binaryBody?: ArrayBuffer;
   requestHeaders?: Record<string, string | undefined>;
 }): Promise<EditorHandlerResult> => {
-  const { method, subpath, config, runtime, supabaseEnv } = options;
+  const { method, subpath, config, runtime, supabaseEnv, authProfile } = options;
   const body = (options.body ?? {}) as Record<string, unknown>;
   const usageStore = createTranslateUsageStore(supabaseEnv ?? {});
+
+  if (method === 'POST' && subpath.startsWith('admin/')) {
+    if (!authProfile) return fail('No autenticado.', 401);
+    return handleAdminRoute({
+      subpath,
+      body,
+      profile: authProfile,
+      env: supabaseEnv ?? {},
+    });
+  }
 
   if (method === 'POST' && subpath === 'prepare-archive-audio-upload') {
     const accessKey = config.archive?.accessKey || '';
@@ -57,6 +71,9 @@ export const handleEditorRoute = async (options: {
 
     if (!programId || !episodeId) {
       return fail('Faltan campos requeridos.');
+    }
+    if (authProfile && !canAccessProgram(authProfile, programId)) {
+      return fail('No tenés permiso para subir audio a este programa.', 403);
     }
     if (mimeType !== 'audio/mpeg' && mimeType !== 'audio/mp3') {
       return fail('Solo se permite subir MP3 a Archive.org.');
@@ -110,6 +127,9 @@ export const handleEditorRoute = async (options: {
     if (!meta.programId || !meta.episodeId) {
       return fail('Faltan metadatos del episodio (programId, episodeId).');
     }
+    if (authProfile && !canAccessProgram(authProfile, meta.programId)) {
+      return fail('No tenés permiso para subir audio a este programa.', 403);
+    }
 
     try {
       const uploaded = await uploadEpisodeAudioToArchive({
@@ -146,6 +166,9 @@ export const handleEditorRoute = async (options: {
 
     if (!programId || !episodeId || !body.dataBase64 || !mimeType || !ext) {
       return fail('Faltan campos requeridos o mimeType inválido.');
+    }
+    if (authProfile && !canAccessProgram(authProfile, programId)) {
+      return fail('No tenés permiso para subir audio a este programa.', 403);
     }
 
     try {

--- a/functions/_shared/editorAuth.ts
+++ b/functions/_shared/editorAuth.ts
@@ -1,0 +1,167 @@
+import { jsonResponse, readBearerToken } from './supabaseJwtAuth';
+
+export type EditorRole = 'admin' | 'editor';
+
+export interface EditorAuthProfile {
+  userId: string;
+  role: EditorRole;
+  programId: string | null;
+  disabledAt: string | null;
+}
+
+export interface SupabaseAuthEnv {
+  SUPABASE_URL?: string;
+  SUPABASE_ANON_KEY?: string;
+  SUPABASE_SERVICE_ROLE_KEY?: string;
+}
+
+const parseProfileRow = (row: Record<string, unknown>): EditorAuthProfile | null => {
+  const role = String(row.role || '');
+  if (role !== 'admin' && role !== 'editor') return null;
+  return {
+    userId: String(row.user_id || ''),
+    role,
+    programId: row.program_id == null ? null : String(row.program_id),
+    disabledAt: row.disabled_at == null ? null : String(row.disabled_at),
+  };
+};
+
+export const fetchAuthUserId = async (
+  token: string,
+  env: Pick<SupabaseAuthEnv, 'SUPABASE_URL' | 'SUPABASE_ANON_KEY'>
+): Promise<string | null> => {
+  const url = (env.SUPABASE_URL || '').trim();
+  const anonKey = (env.SUPABASE_ANON_KEY || '').trim();
+  if (!url || !anonKey || !token) return null;
+
+  const response = await fetch(`${url}/auth/v1/user`, {
+    headers: { Authorization: `Bearer ${token}`, apikey: anonKey },
+  });
+  if (!response.ok) return null;
+  const data = (await response.json()) as { id?: string };
+  return data.id ? String(data.id) : null;
+};
+
+export const fetchEditorProfile = async (
+  token: string,
+  env: Pick<SupabaseAuthEnv, 'SUPABASE_URL' | 'SUPABASE_ANON_KEY'>
+): Promise<EditorAuthProfile | null> => {
+  const url = (env.SUPABASE_URL || '').trim();
+  const anonKey = (env.SUPABASE_ANON_KEY || '').trim();
+  if (!url || !anonKey || !token) return null;
+
+  const response = await fetch(
+    `${url}/rest/v1/editor_profiles?select=user_id,role,program_id,disabled_at&limit=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        apikey: anonKey,
+        Accept: 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) return null;
+  const rows = (await response.json()) as Record<string, unknown>[];
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  return parseProfileRow(rows[0]!);
+};
+
+export interface AssertEditorAuthOptions {
+  requireAdmin?: boolean;
+  programId?: string;
+}
+
+export const assertEditorAuthorized = async (
+  request: Request,
+  env: Pick<SupabaseAuthEnv, 'SUPABASE_URL' | 'SUPABASE_ANON_KEY'>,
+  options: AssertEditorAuthOptions = {}
+): Promise<{ error: Response } | { profile: EditorAuthProfile; token: string }> => {
+  const url = (env.SUPABASE_URL || '').trim();
+  const anonKey = (env.SUPABASE_ANON_KEY || '').trim();
+  const token = readBearerToken(request);
+
+  if (!url || !anonKey) {
+    return {
+      error: jsonResponse(503, {
+        ok: false,
+        message: 'Faltan SUPABASE_URL o SUPABASE_ANON_KEY en el servidor.',
+      }),
+    };
+  }
+
+  if (!token) {
+    return {
+      error: jsonResponse(401, {
+        ok: false,
+        message: 'Sesión del editor inválida. Volvé a /editor-login.',
+      }),
+    };
+  }
+
+  const userId = await fetchAuthUserId(token, env);
+  if (!userId) {
+    return {
+      error: jsonResponse(401, {
+        ok: false,
+        message: 'Sesión del editor inválida. Volvé a /editor-login.',
+      }),
+    };
+  }
+
+  const profile = await fetchEditorProfile(token, env);
+  if (!profile || profile.userId !== userId) {
+    return {
+      error: jsonResponse(403, {
+        ok: false,
+        message: 'No tenés perfil de editor. Contactá a un administrador.',
+      }),
+    };
+  }
+
+  if (profile.disabledAt) {
+    return {
+      error: jsonResponse(403, {
+        ok: false,
+        message: 'Tu cuenta de editor está desactivada.',
+      }),
+    };
+  }
+
+  if (profile.role === 'editor' && !profile.programId) {
+    return {
+      error: jsonResponse(403, {
+        ok: false,
+        message: 'Tu cuenta no tiene un programa asignado.',
+      }),
+    };
+  }
+
+  if (options.requireAdmin && profile.role !== 'admin') {
+    return {
+      error: jsonResponse(403, {
+        ok: false,
+        message: 'Solo administradores pueden realizar esta acción.',
+      }),
+    };
+  }
+
+  if (options.programId) {
+    const allowed =
+      profile.role === 'admin' ||
+      (profile.role === 'editor' && profile.programId === options.programId);
+    if (!allowed) {
+      return {
+        error: jsonResponse(403, {
+          ok: false,
+          message: 'No tenés permiso para editar este programa.',
+        }),
+      };
+    }
+  }
+
+  return { profile, token };
+};
+
+export const canAccessProgram = (profile: EditorAuthProfile, programId: string): boolean =>
+  profile.role === 'admin' || profile.programId === programId;

--- a/openspec/changes/add-editor-roles/proposal.md
+++ b/openspec/changes/add-editor-roles/proposal.md
@@ -1,0 +1,17 @@
+# Change: Roles editor y admin (RBAC por programa)
+
+## Why
+
+Varios colaboradores deben editar solo su programa sin tocar el resto del sitio ni la configuración global.
+
+## What Changes
+
+- Tabla `editor_profiles` con roles `admin` y `editor`
+- RLS en Postgres y Storage acotado por `program_id`
+- Panel `/admin/usuarios` para altas y asignación de programa
+- Guards en cliente y Cloudflare Functions
+
+## Impact
+
+- Affected code: `EditorContext`, editor Functions, páginas de edición, `scripts/supabase-editor-roles-migration.sql`
+- Requiere ejecutar migración SQL en Supabase antes de usar en producción

--- a/openspec/changes/add-editor-roles/specs/content-editor/spec.md
+++ b/openspec/changes/add-editor-roles/specs/content-editor/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Editor role assignment
+
+The system SHALL store each authenticated editor user in `editor_profiles` with role `admin` or `editor`. Users with role `editor` MUST have exactly one `program_id` referencing a `content_items` row with `content_kind = program`. Users with role `admin` MUST have `program_id` NULL.
+
+#### Scenario: Editor assigned to program
+
+- **WHEN** an admin creates a user with role `editor` and program `chicas-malas`
+- **THEN** that user can upsert only rows for program `chicas-malas` and related episodes
+
+#### Scenario: Editor blocked on other program
+
+- **WHEN** an editor assigned to program A attempts to update content for program B
+- **THEN** the database RLS denies the write
+
+### Requirement: Admin user management
+
+The system SHALL expose `/admin/usuarios` for users with role `admin` to list, create, disable, and assign programs to editor users.
+
+#### Scenario: Non-admin denied
+
+- **WHEN** a user with role `editor` opens `/admin/usuarios`
+- **THEN** they are redirected away from the admin panel
+
+### Requirement: Editorial content restricted to admin
+
+The system SHALL allow updates to `site_editorial` and `home-hero` storage only for role `admin`.
+
+#### Scenario: Editor cannot edit home copy
+
+- **WHEN** an editor is authenticated and visits the home page
+- **THEN** inline editorial controls are not shown

--- a/openspec/changes/add-editor-roles/tasks.md
+++ b/openspec/changes/add-editor-roles/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Migración SQL `editor_profiles` + RLS + Storage
+- [x] 1.2 Autorización en Functions (`editorAuth`, admin routes)
+- [x] 1.3 `EditorContext` con rol, guards y redirect en login
+- [x] 1.4 UI: guards en páginas + `AdminUsersPage` + i18n
+- [x] 1.5 Documentación en `docs/es/content-management.md`

--- a/scripts/editorDevServerPlugin.ts
+++ b/scripts/editorDevServerPlugin.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'vite';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { handleEditorRoute } from '../functions/_shared/editor/handlers';
-import { assertSupabaseJwtAuthorized } from '../functions/_shared/supabaseJwtAuth';
+import { assertEditorAuthorized } from '../functions/_shared/editorAuth';
 
 interface PluginOptions {
   enabled: boolean;
@@ -104,17 +104,19 @@ export const editorDevServerPlugin = ({
           ),
         });
 
-        const authError = await assertSupabaseJwtAuthorized(authRequest, {
-          SUPABASE_URL: supabaseUrl,
-          SUPABASE_ANON_KEY: supabaseAnonKey,
-        });
-        if (authError) {
-          const payload = await authError.json();
-          return sendJson(res, authError.status, payload);
-        }
-
         const url = req.url || '/';
         const subpath = url.replace(/^\//, '').split('?')[0];
+
+        const authResult = await assertEditorAuthorized(authRequest, {
+          SUPABASE_URL: supabaseUrl,
+          SUPABASE_ANON_KEY: supabaseAnonKey,
+        }, {
+          requireAdmin: subpath.startsWith('admin/'),
+        });
+        if ('error' in authResult) {
+          const payload = await authResult.error.json();
+          return sendJson(res, authResult.error.status, payload);
+        }
         const method = req.method || 'GET';
         const requestHeaders = headerRecord(req);
         const isAudioProxy = method === 'POST' && subpath === 'upload-episode-audio-proxy';
@@ -150,8 +152,10 @@ export const editorDevServerPlugin = ({
           },
           supabaseEnv: {
             SUPABASE_URL: supabaseUrl,
+            SUPABASE_ANON_KEY: supabaseAnonKey,
             SUPABASE_SERVICE_ROLE_KEY: serviceKey,
           },
+          authProfile: authResult.profile,
         });
 
         return sendJson(res, result.status, result.body);

--- a/scripts/supabase-editor-roles-migration.sql
+++ b/scripts/supabase-editor-roles-migration.sql
@@ -1,0 +1,363 @@
+-- Editor roles: admin (global) vs editor (single program)
+-- Ejecutar en Supabase Dashboard → SQL Editor (después de storage setup si aplica).
+--
+-- Bootstrap: todos los usuarios auth existentes pasan a role = admin.
+-- Nuevos editores: asignar program_id desde /admin/usuarios o INSERT manual.
+
+-- ---------------------------------------------------------------------------
+-- 1. Tabla editor_profiles
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.editor_profiles (
+  user_id uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  role text NOT NULL CHECK (role IN ('admin', 'editor')),
+  program_id text NULL REFERENCES public.content_items (id) ON DELETE SET NULL,
+  disabled_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT editor_profiles_admin_no_program CHECK (
+    (role = 'admin' AND program_id IS NULL)
+    OR (role = 'editor' AND program_id IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS editor_profiles_program_id_idx ON public.editor_profiles (program_id);
+
+-- Solo programas (no eventos) pueden asignarse a editores
+CREATE OR REPLACE FUNCTION public.editor_profiles_validate_program()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.role = 'editor' AND NEW.program_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.content_items ci
+      WHERE ci.id = NEW.program_id AND ci.content_kind = 'program'
+    ) THEN
+      RAISE EXCEPTION 'program_id debe ser un content_items con content_kind = program';
+    END IF;
+  END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS editor_profiles_validate_program_trg ON public.editor_profiles;
+CREATE TRIGGER editor_profiles_validate_program_trg
+BEFORE INSERT OR UPDATE ON public.editor_profiles
+FOR EACH ROW EXECUTE FUNCTION public.editor_profiles_validate_program();
+
+-- ---------------------------------------------------------------------------
+-- 2. Helpers (SECURITY DEFINER para evitar recursión RLS)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.current_editor_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT role FROM public.editor_profiles
+  WHERE user_id = auth.uid() AND disabled_at IS NULL
+  LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_editor_program_id()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT program_id FROM public.editor_profiles
+  WHERE user_id = auth.uid() AND role = 'editor' AND disabled_at IS NULL
+  LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_editor_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(public.current_editor_role() = 'admin', false);
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_editor_active()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.editor_profiles
+    WHERE user_id = auth.uid() AND disabled_at IS NULL
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.editor_storage_program_prefix(program_id text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT lower(regexp_replace(COALESCE(program_id, ''), '[^a-zA-Z0-9-]', '-', 'g'));
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_edit_program(target_program_id text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT CASE
+    WHEN NOT public.is_editor_active() THEN false
+    WHEN public.is_editor_admin() THEN true
+    WHEN public.current_editor_program_id() IS NOT NULL
+         AND public.current_editor_program_id() = target_program_id THEN true
+    ELSE false
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_edit_storage_object(bucket text, object_name text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT CASE
+    WHEN NOT public.is_editor_active() THEN false
+    WHEN bucket = 'home-hero' THEN public.is_editor_admin()
+    WHEN bucket IN ('program-logos', 'episode-covers', 'episode-audio') THEN
+      public.is_editor_admin()
+      OR (
+        public.current_editor_program_id() IS NOT NULL
+        AND lower(object_name) LIKE public.editor_storage_program_prefix(public.current_editor_program_id()) || '-%'
+      )
+    ELSE false
+  END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Bootstrap admins para usuarios Auth existentes
+-- ---------------------------------------------------------------------------
+
+INSERT INTO public.editor_profiles (user_id, role, program_id)
+SELECT id, 'admin', NULL FROM auth.users
+ON CONFLICT (user_id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- 4. RLS editor_profiles
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.editor_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS editor_profiles_select ON public.editor_profiles;
+CREATE POLICY editor_profiles_select ON public.editor_profiles
+FOR SELECT TO authenticated
+USING (user_id = auth.uid() OR public.is_editor_admin());
+
+DROP POLICY IF EXISTS editor_profiles_admin_insert ON public.editor_profiles;
+CREATE POLICY editor_profiles_admin_insert ON public.editor_profiles
+FOR INSERT TO authenticated
+WITH CHECK (public.is_editor_admin());
+
+DROP POLICY IF EXISTS editor_profiles_admin_update ON public.editor_profiles;
+CREATE POLICY editor_profiles_admin_update ON public.editor_profiles
+FOR UPDATE TO authenticated
+USING (public.is_editor_admin())
+WITH CHECK (public.is_editor_admin());
+
+DROP POLICY IF EXISTS editor_profiles_admin_delete ON public.editor_profiles;
+CREATE POLICY editor_profiles_admin_delete ON public.editor_profiles
+FOR DELETE TO authenticated
+USING (public.is_editor_admin());
+
+-- ---------------------------------------------------------------------------
+-- 5. RLS escritura en tablas de contenido (no toca lectura pública existente)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.content_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.content_item_translations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.episodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.episode_translations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.site_editorial ENABLE ROW LEVEL SECURITY;
+
+-- content_items
+DROP POLICY IF EXISTS editor_roles_content_items_insert ON public.content_items;
+CREATE POLICY editor_roles_content_items_insert ON public.content_items
+FOR INSERT TO authenticated
+WITH CHECK (public.can_edit_program(id));
+
+DROP POLICY IF EXISTS editor_roles_content_items_update ON public.content_items;
+CREATE POLICY editor_roles_content_items_update ON public.content_items
+FOR UPDATE TO authenticated
+USING (public.can_edit_program(id))
+WITH CHECK (public.can_edit_program(id));
+
+DROP POLICY IF EXISTS editor_roles_content_items_delete ON public.content_items;
+CREATE POLICY editor_roles_content_items_delete ON public.content_items
+FOR DELETE TO authenticated
+USING (public.can_edit_program(id));
+
+-- content_item_translations
+DROP POLICY IF EXISTS editor_roles_content_item_translations_insert ON public.content_item_translations;
+CREATE POLICY editor_roles_content_item_translations_insert ON public.content_item_translations
+FOR INSERT TO authenticated
+WITH CHECK (public.can_edit_program(content_item_id));
+
+DROP POLICY IF EXISTS editor_roles_content_item_translations_update ON public.content_item_translations;
+CREATE POLICY editor_roles_content_item_translations_update ON public.content_item_translations
+FOR UPDATE TO authenticated
+USING (public.can_edit_program(content_item_id))
+WITH CHECK (public.can_edit_program(content_item_id));
+
+DROP POLICY IF EXISTS editor_roles_content_item_translations_delete ON public.content_item_translations;
+CREATE POLICY editor_roles_content_item_translations_delete ON public.content_item_translations
+FOR DELETE TO authenticated
+USING (public.can_edit_program(content_item_id));
+
+-- episodes
+DROP POLICY IF EXISTS editor_roles_episodes_insert ON public.episodes;
+CREATE POLICY editor_roles_episodes_insert ON public.episodes
+FOR INSERT TO authenticated
+WITH CHECK (public.can_edit_program(program_id));
+
+DROP POLICY IF EXISTS editor_roles_episodes_update ON public.episodes;
+CREATE POLICY editor_roles_episodes_update ON public.episodes
+FOR UPDATE TO authenticated
+USING (public.can_edit_program(program_id))
+WITH CHECK (public.can_edit_program(program_id));
+
+DROP POLICY IF EXISTS editor_roles_episodes_delete ON public.episodes;
+CREATE POLICY editor_roles_episodes_delete ON public.episodes
+FOR DELETE TO authenticated
+USING (public.can_edit_program(program_id));
+
+-- episode_translations (via episodes.program_id)
+DROP POLICY IF EXISTS editor_roles_episode_translations_insert ON public.episode_translations;
+CREATE POLICY editor_roles_episode_translations_insert ON public.episode_translations
+FOR INSERT TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.episodes e
+    WHERE e.id = episode_id AND public.can_edit_program(e.program_id)
+  )
+);
+
+DROP POLICY IF EXISTS editor_roles_episode_translations_update ON public.episode_translations;
+CREATE POLICY editor_roles_episode_translations_update ON public.episode_translations
+FOR UPDATE TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.episodes e
+    WHERE e.id = episode_id AND public.can_edit_program(e.program_id)
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.episodes e
+    WHERE e.id = episode_id AND public.can_edit_program(e.program_id)
+  )
+);
+
+DROP POLICY IF EXISTS editor_roles_episode_translations_delete ON public.episode_translations;
+CREATE POLICY editor_roles_episode_translations_delete ON public.episode_translations
+FOR DELETE TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.episodes e
+    WHERE e.id = episode_id AND public.can_edit_program(e.program_id)
+  )
+);
+
+-- site_editorial: solo admin
+DROP POLICY IF EXISTS editor_roles_site_editorial_all ON public.site_editorial;
+CREATE POLICY editor_roles_site_editorial_all ON public.site_editorial
+FOR ALL TO authenticated
+USING (public.is_editor_admin())
+WITH CHECK (public.is_editor_admin());
+
+-- ---------------------------------------------------------------------------
+-- 6. Storage: reemplazar políticas authenticated por rol/programa
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS program_logos_authenticated_insert ON storage.objects;
+CREATE POLICY program_logos_authenticated_insert ON storage.objects
+FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'program-logos'
+  AND public.can_edit_storage_object(bucket_id, name)
+);
+
+DROP POLICY IF EXISTS program_logos_authenticated_update ON storage.objects;
+CREATE POLICY program_logos_authenticated_update ON storage.objects
+FOR UPDATE TO authenticated
+USING (bucket_id = 'program-logos' AND public.can_edit_storage_object(bucket_id, name))
+WITH CHECK (bucket_id = 'program-logos' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS program_logos_authenticated_delete ON storage.objects;
+CREATE POLICY program_logos_authenticated_delete ON storage.objects
+FOR DELETE TO authenticated
+USING (bucket_id = 'program-logos' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS episode_covers_authenticated_insert ON storage.objects;
+CREATE POLICY episode_covers_authenticated_insert ON storage.objects
+FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'episode-covers'
+  AND public.can_edit_storage_object(bucket_id, name)
+);
+
+DROP POLICY IF EXISTS episode_covers_authenticated_update ON storage.objects;
+CREATE POLICY episode_covers_authenticated_update ON storage.objects
+FOR UPDATE TO authenticated
+USING (bucket_id = 'episode-covers' AND public.can_edit_storage_object(bucket_id, name))
+WITH CHECK (bucket_id = 'episode-covers' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS episode_covers_authenticated_delete ON storage.objects;
+CREATE POLICY episode_covers_authenticated_delete ON storage.objects
+FOR DELETE TO authenticated
+USING (bucket_id = 'episode-covers' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS episode_audio_authenticated_insert ON storage.objects;
+CREATE POLICY episode_audio_authenticated_insert ON storage.objects
+FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'episode-audio'
+  AND public.can_edit_storage_object(bucket_id, name)
+);
+
+DROP POLICY IF EXISTS episode_audio_authenticated_update ON storage.objects;
+CREATE POLICY episode_audio_authenticated_update ON storage.objects
+FOR UPDATE TO authenticated
+USING (bucket_id = 'episode-audio' AND public.can_edit_storage_object(bucket_id, name))
+WITH CHECK (bucket_id = 'episode-audio' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS episode_audio_authenticated_delete ON storage.objects;
+CREATE POLICY episode_audio_authenticated_delete ON storage.objects
+FOR DELETE TO authenticated
+USING (bucket_id = 'episode-audio' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS home_hero_authenticated_insert ON storage.objects;
+CREATE POLICY home_hero_authenticated_insert ON storage.objects
+FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'home-hero' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS home_hero_authenticated_update ON storage.objects;
+CREATE POLICY home_hero_authenticated_update ON storage.objects
+FOR UPDATE TO authenticated
+USING (bucket_id = 'home-hero' AND public.can_edit_storage_object(bucket_id, name))
+WITH CHECK (bucket_id = 'home-hero' AND public.can_edit_storage_object(bucket_id, name));
+
+DROP POLICY IF EXISTS home_hero_authenticated_delete ON storage.objects;
+CREATE POLICY home_hero_authenticated_delete ON storage.objects
+FOR DELETE TO authenticated
+USING (bucket_id = 'home-hero' AND public.can_edit_storage_object(bucket_id, name));
+
+-- Nota: si tras migrar un editor aún puede escribir en tablas ajenas, revisá en Dashboard
+-- políticas authenticated heredadas y eliminá las permisivas que no empiecen por editor_roles_.

--- a/src/components/LanguageRouter.tsx
+++ b/src/components/LanguageRouter.tsx
@@ -18,7 +18,9 @@ import SchedulePage from '../pages/SchedulePage';
 import ProgramDetailPage from '../pages/ProgramDetailPage';
 import EpisodeDetailPage from '../pages/EpisodeDetailPage';
 import EditorLoginPage from '../pages/EditorLoginPage';
+import AdminUsersPage from '../pages/AdminUsersPage';
 import ContactPage from '../pages/ContactPage';
+import { EditorProvider } from '../contexts/EditorContext';
 
 /**
  * Language Router Component
@@ -60,7 +62,13 @@ const LanguageDetector: React.FC<{ children: React.ReactNode }> = ({ children })
     if (!isI18nReady) return;
 
     const currentPath = location.pathname;
-    if (currentPath === '/editor-login' || currentPath === '/editor_login') return;
+    if (
+      currentPath === '/editor-login' ||
+      currentPath === '/editor_login' ||
+      currentPath.startsWith('/admin/')
+    ) {
+      return;
+    }
 
     const pathSegments = currentPath.split('/').filter(Boolean);
     const firstSegment = pathSegments[0];
@@ -142,6 +150,14 @@ const AppRoutes: React.FC = () => {
       {/* Editor login (misma ruta en local y prod) */}
       <Route path="/editor-login" element={<EditorLoginPage />} />
       <Route path="/editor_login" element={<Navigate to="/editor-login" replace />} />
+      <Route
+        path="/admin/usuarios"
+        element={
+          <EditorProvider>
+            <AdminUsersPage />
+          </EditorProvider>
+        }
+      />
 
       {/* Catch-all route for 404 */}
       <Route path="*" element={<NotFound />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -218,6 +218,14 @@ const Navigation: React.FC<NavigationProps> = ({
               {t('navigation.login')}
             </Link>
           )}
+          {editor?.isAdmin && (
+            <Link
+              to="/admin/usuarios"
+              className="shrink-0 border border-white/30 px-2.5 py-1 text-[10px] uppercase tracking-widest text-white/70 transition hover:border-white hover:text-white"
+            >
+              {t('navigation.admin')}
+            </Link>
+          )}
           {editor?.enabled && (
             <div className="flex shrink-0 items-center gap-3">
               {editor.message ? (
@@ -328,6 +336,15 @@ const Navigation: React.FC<NavigationProps> = ({
                       className="block w-full border border-white/30 bg-white/[0.02] px-4 py-4 text-center font-['Space_Grotesk'] text-[15px] uppercase tracking-[0.14em] text-white/75 transition hover:border-white hover:text-white"
                     >
                       {t('navigation.login')}
+                    </Link>
+                  )}
+                  {editor?.isAdmin && (
+                    <Link
+                      to="/admin/usuarios"
+                      onClick={handleMobileNavClick}
+                      className="block w-full border border-white/30 bg-white/[0.02] px-4 py-4 text-center font-['Space_Grotesk'] text-[15px] uppercase tracking-[0.14em] text-white/75 transition hover:border-white hover:text-white"
+                    >
+                      {t('navigation.admin')}
                     </Link>
                   )}
                   {editor?.enabled && (

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -28,6 +28,14 @@ import {
   isEditorAvailable,
   subscribeAuth,
 } from '../lib/supabaseClient';
+import {
+  canEditEditorial as profileCanEditEditorial,
+  canEditProgram as profileCanEditProgram,
+  canManagePrograms as profileCanManagePrograms,
+  fetchEditorProfile,
+  type EditorProfile,
+  type EditorRole,
+} from '../services/editorProfileService';
 import { useOptionalPublicContent } from './PublicContentContext';
 import { mapRouteToContentIndexLanguage } from '../utils/contentLanguage';
 import { queryClient } from '../lib/queryClient';
@@ -37,6 +45,12 @@ type LocalizedTextValues = Record<EditorLanguage, string>;
 interface EditorContextValue {
   enabled: boolean;
   authenticated: boolean;
+  role: EditorRole | null;
+  isAdmin: boolean;
+  assignedProgramId: string | null;
+  canEditProgram: (programId: string) => boolean;
+  canEditEditorial: () => boolean;
+  canManagePrograms: () => boolean;
   loading: boolean;
   saving: boolean;
   isDirty: boolean;
@@ -184,7 +198,33 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   );
   const editorAvailable = isEditorAvailable();
   const [authenticated, setAuthenticated] = React.useState(false);
-  const active = editorAvailable && authenticated;
+  const [profile, setProfile] = React.useState<EditorProfile | null>(null);
+  const active = editorAvailable && authenticated && Boolean(profile) && !profile?.disabledAt;
+
+  const canEditProgram = React.useCallback(
+    (programId: string) => profileCanEditProgram(profile, programId),
+    [profile]
+  );
+  const canEditEditorial = React.useCallback(() => profileCanEditEditorial(profile), [profile]);
+  const canManagePrograms = React.useCallback(() => profileCanManagePrograms(profile), [profile]);
+
+  const denyProgramEdit = React.useCallback((programId: string): boolean => {
+    if (canEditProgram(programId)) return false;
+    setMessage('No tenés permiso para editar este programa.');
+    return true;
+  }, [canEditProgram]);
+
+  const denyEditorialEdit = React.useCallback((): boolean => {
+    if (canEditEditorial()) return false;
+    setMessage('Solo administradores pueden editar textos del sitio.');
+    return true;
+  }, [canEditEditorial]);
+
+  const denyManagePrograms = React.useCallback((): boolean => {
+    if (canManagePrograms()) return false;
+    setMessage('Solo administradores pueden gestionar programas.');
+    return true;
+  }, [canManagePrograms]);
   const [loading, setLoading] = React.useState(editorAvailable);
   const [saving, setSaving] = React.useState(false);
   const [message, setMessage] = React.useState<string | null>(null);
@@ -213,6 +253,54 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   React.useEffect(() => {
+    if (!authenticated) {
+      setProfile(null);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const nextProfile = await fetchEditorProfile();
+        if (cancelled) return;
+        if (!nextProfile) {
+          const client = getSupabaseClient();
+          if (client) await client.auth.signOut();
+          setAuthenticated(false);
+          setProfile(null);
+          setMessage('No tenés perfil de editor. Contactá a un administrador.');
+          return;
+        }
+        if (nextProfile.disabledAt) {
+          const client = getSupabaseClient();
+          if (client) await client.auth.signOut();
+          setAuthenticated(false);
+          setProfile(null);
+          setMessage('Tu cuenta de editor está desactivada.');
+          return;
+        }
+        if (nextProfile.role === 'editor' && !nextProfile.programId) {
+          const client = getSupabaseClient();
+          if (client) await client.auth.signOut();
+          setAuthenticated(false);
+          setProfile(null);
+          setMessage('Tu cuenta no tiene un programa asignado.');
+          return;
+        }
+        setProfile(nextProfile);
+      } catch (error) {
+        if (cancelled) return;
+        setProfile(null);
+        setMessage(error instanceof Error ? error.message : 'Error al cargar perfil de editor.');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated]);
+
+  React.useEffect(() => {
     if (authenticated) return;
     if (publicContent?.contentIndex) {
       setContentIndex(publicContent.contentIndex);
@@ -233,11 +321,12 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     const client = getSupabaseClient();
     if (client) await client.auth.signOut();
     setAuthenticated(false);
+    setProfile(null);
     setMessage('Modo editor desactivado.');
   }, []);
 
   React.useEffect(() => {
-    if (!editorAvailable || !authenticated) {
+    if (!editorAvailable || !authenticated || !profile) {
       setLoading(false);
       return;
     }
@@ -245,17 +334,24 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     const loadInitialData = async () => {
       setLoading(true);
       try {
-        const [content, editorialData] = await Promise.all([
-          fetchEditorContentIndexFromSupabase(),
-          fetchEditorialFromSupabase(),
-        ]);
+        const contentFilter =
+          profile.role === 'editor' && profile.programId
+            ? { programId: profile.programId }
+            : undefined;
+        const content = await fetchEditorContentIndexFromSupabase(contentFilter);
         if (content) {
           setContentIndex(content);
           setBaseContentIndex(clone(content));
         }
-        if (editorialData) {
-          setEditorial(editorialData);
-          setBaseEditorial(clone(editorialData));
+        if (profile.role === 'admin') {
+          const editorialData = await fetchEditorialFromSupabase();
+          if (editorialData) {
+            setEditorial(editorialData);
+            setBaseEditorial(clone(editorialData));
+          }
+        } else {
+          setEditorial(emptyEditorial());
+          setBaseEditorial(emptyEditorial());
         }
       } catch (error) {
         setMessage(error instanceof Error ? error.message : 'Error al cargar el editor.');
@@ -265,14 +361,17 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     };
 
     void loadInitialData();
-  }, [authenticated, editorAvailable]);
+  }, [authenticated, editorAvailable, profile]);
 
   React.useEffect(() => {
-    if (!editorAvailable || !authenticated) return;
+    if (!editorAvailable || !authenticated || !profile) return;
+
+    const contentFilter =
+      profile.role === 'editor' && profile.programId ? { programId: profile.programId } : undefined;
 
     const resyncFromDb = () => {
       if (document.hidden) return;
-      void fetchEditorContentIndexFromSupabase()
+      void fetchEditorContentIndexFromSupabase(contentFilter)
         .then((content) => {
           if (!content) return;
           setContentIndex(content);
@@ -283,7 +382,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     document.addEventListener('visibilitychange', resyncFromDb);
     return () => document.removeEventListener('visibilitychange', resyncFromDb);
-  }, [authenticated, editorAvailable]);
+  }, [authenticated, editorAvailable, profile]);
 
   const updateContentField = (programId: string, lang: EditorLanguage, field: string, value: unknown) => {
     setContentIndex((prev) => {
@@ -302,6 +401,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     field: string,
     value: unknown
   ) => {
+    if (denyProgramEdit(programId)) return;
     const nextContent = clone(contentIndex);
     const entry = nextContent?.[programId] as Record<string, unknown> | undefined;
     if (!entry) return;
@@ -320,6 +420,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     field: string,
     values: LocalizedTextValues
   ) => {
+    if (denyProgramEdit(programId)) return;
     const nextContent = clone(contentIndex);
     const entry = nextContent?.[programId];
     if (!entry) return;
@@ -335,6 +436,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const commitContentFieldAllLanguages = async (programId: string, field: string, value: unknown) => {
+    if (denyProgramEdit(programId)) return;
     const nextContent = clone(contentIndex);
     const entry = nextContent?.[programId];
     if (!entry) return;
@@ -351,6 +453,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   /** Tras subir logo: Storage + logo_url ya están en DB; sincroniza estado local y contenido público. */
   const applyUploadedProgramLogo = async (programId: string, url: string, uploadMessage: string) => {
+    if (denyProgramEdit(programId)) return;
     setContentIndex((prev) => {
       const next = clone(prev);
       const entry = next[programId];
@@ -370,7 +473,9 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       return next;
     });
 
-    const content = await fetchEditorContentIndexFromSupabase();
+    const contentFilter =
+      profile?.role === 'editor' && profile.programId ? { programId: profile.programId } : undefined;
+    const content = await fetchEditorContentIndexFromSupabase(contentFilter);
     if (content) {
       setContentIndex(content);
       setBaseContentIndex(clone(content));
@@ -386,6 +491,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     url: string,
     uploadMessage: string
   ) => {
+    if (denyProgramEdit(programId)) return;
     setEpisodesByProgram((prev) => {
       const next = clone(prev);
       const program = next[programId];
@@ -415,6 +521,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     programId: string,
     fields: Record<string, unknown>
   ) => {
+    if (denyProgramEdit(programId)) return;
     const nextContent = clone(contentIndex);
     const entry = nextContent?.[programId];
     if (!entry) return;
@@ -450,6 +557,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const episodesLoaded = React.useRef(new Set<string>());
 
   const loadEpisodes = React.useCallback(async (programId: string) => {
+    if (!profileCanEditProgram(profile, programId)) return;
     if (episodesLoaded.current.has(programId)) return;
 
     const inFlight = episodesLoadInFlight.current.get(programId);
@@ -468,7 +576,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     episodesLoadInFlight.current.set(programId, promise);
     return promise;
-  }, [routeLang]);
+  }, [routeLang, profile]);
 
   const updateEpisodeField = (programId: string, episodeId: string, field: string, value: unknown) => {
     setEpisodesByProgram((prev) => {
@@ -488,6 +596,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     field: string,
     value: unknown
   ) => {
+    if (denyProgramEdit(programId)) return;
     const sourceProgram =
       episodesByProgram[programId] ??
       (await devEditorService.fetchProgramEpisodes(programId).catch(
@@ -530,6 +639,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       archiveIdentifier?: string;
     }
   ): Promise<string | null> => {
+    if (denyProgramEdit(programId)) return null;
     const sourceProgram =
       episodesByProgram[programId] ??
       (await devEditorService.fetchProgramEpisodes(programId).catch(
@@ -562,6 +672,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const removeEpisode = async (programId: string, episodeId: string) => {
     if (!active) return;
+    if (denyProgramEdit(programId)) return;
 
     const sourceProgram =
       episodesByProgram[programId] ??
@@ -606,6 +717,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const restoreEpisode = async (programId: string, episodeId: string) => {
     if (!active) return;
+    if (denyProgramEdit(programId)) return;
 
     const trash = episodesTrashByProgram[programId];
     const episode = trash?.episodes.find((item) => item.id === episodeId);
@@ -641,6 +753,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const purgeEpisode = async (programId: string, episodeId: string) => {
+    if (denyProgramEdit(programId)) return;
     setEpisodesTrashByProgram((prev) => {
       const next = clone(prev);
       const trash = next[programId];
@@ -749,6 +862,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     lang: EditorLanguage,
     value: string
   ) => {
+    if (denyEditorialEdit()) return;
     const nextEditorial = clone(editorial);
     const target = (nextEditorial[section] as Record<string, unknown>)[field] as Record<string, string> | undefined;
     if (!target) return;
@@ -766,6 +880,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     field: string,
     values: LocalizedTextValues
   ) => {
+    if (denyEditorialEdit()) return;
     const nextEditorial = clone(editorial);
     const target = (nextEditorial[section] as Record<string, unknown>)[field] as
       | Record<string, string>
@@ -788,6 +903,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const commitAboutCredits = async (nextCredits: AboutCreditsData) => {
+    if (denyEditorialEdit()) return;
     const nextEditorial = clone(editorial);
     nextEditorial.about = { ...nextEditorial.about, credits: nextCredits };
     setEditorial(nextEditorial);
@@ -798,6 +914,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const commitHomeDefaultHeroImage = async (url: string) => {
+    if (denyEditorialEdit()) return;
     const nextEditorial = clone(editorial);
     nextEditorial.home = { ...nextEditorial.home, defaultHeroImageUrl: url };
     setEditorial(nextEditorial);
@@ -808,6 +925,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   };
 
   const applyUploadedHomeHero = async (url: string, uploadMessage: string) => {
+    if (denyEditorialEdit()) return;
     const nextEditorial = clone(editorial);
     nextEditorial.home = { ...nextEditorial.home, defaultHeroImageUrl: url };
     setEditorial(nextEditorial);
@@ -819,6 +937,7 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const createProgram = async (payload: CreateProgramPayload): Promise<string | null> => {
     if (!active) return null;
+    if (denyManagePrograms()) return null;
     setSaving(true);
     try {
       const res = await editorSupabaseService.createProgram(payload);
@@ -844,6 +963,8 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   const deleteProgram = async (payload: DeleteProgramPayload): Promise<boolean> => {
     if (!active) return false;
+    if (denyManagePrograms()) return false;
+    if (denyProgramEdit(payload.id)) return false;
     setSaving(true);
     try {
       const res = await editorSupabaseService.deleteProgram(payload);
@@ -891,6 +1012,12 @@ export const EditorProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const value: EditorContextValue = {
     enabled: active,
     authenticated,
+    role: profile?.role ?? null,
+    isAdmin: profile?.role === 'admin',
+    assignedProgramId: profile?.programId ?? null,
+    canEditProgram,
+    canEditEditorial,
+    canManagePrograms,
     loading,
     saving,
     isDirty,

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -23,7 +23,31 @@
     "schedule": "programación",
     "transmitting": "TRANSMITIENDO...",
     "login": "Login",
-    "logout-editor": "Cerrar editor"
+    "logout-editor": "Cerrar editor",
+    "admin": "Admin"
+  },
+  "admin-users": {
+    "title": "Usuarios del editor",
+    "subtitle": "Crear cuentas y asignar programa a cada editor",
+    "create-title": "Nuevo usuario",
+    "email": "Email",
+    "password": "Contraseña",
+    "role": "Rol",
+    "role-editor": "Editor (un programa)",
+    "role-admin": "Administrador",
+    "program": "Programa",
+    "program-placeholder": "Elegir programa…",
+    "create-submit": "Crear usuario",
+    "col-email": "Email",
+    "col-role": "Rol",
+    "col-program": "Programa",
+    "col-status": "Estado",
+    "col-actions": "Acciones",
+    "status-active": "Activo",
+    "status-disabled": "Desactivado",
+    "action-disable": "Desactivar",
+    "action-enable": "Activar",
+    "empty": "No hay usuarios."
   },
   "contact": {
     "page-title": "Radio Nudista — Propuesta de programa",

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -23,7 +23,31 @@
     "schedule": "programação",
     "transmitting": "NO AR...",
     "login": "Login",
-    "logout-editor": "Sair do editor"
+    "logout-editor": "Sair do editor",
+    "admin": "Admin"
+  },
+  "admin-users": {
+    "title": "Usuários do editor",
+    "subtitle": "Criar contas e atribuir programa a cada editor",
+    "create-title": "Novo usuário",
+    "email": "Email",
+    "password": "Senha",
+    "role": "Função",
+    "role-editor": "Editor (um programa)",
+    "role-admin": "Administrador",
+    "program": "Programa",
+    "program-placeholder": "Escolher programa…",
+    "create-submit": "Criar usuário",
+    "col-email": "Email",
+    "col-role": "Função",
+    "col-program": "Programa",
+    "col-status": "Estado",
+    "col-actions": "Ações",
+    "status-active": "Ativo",
+    "status-disabled": "Desativado",
+    "action-disable": "Desativar",
+    "action-enable": "Ativar",
+    "empty": "Não há usuários."
   },
   "contact": {
     "page-title": "Radio Nudista — Proposta de programa",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -14,9 +14,10 @@ const AboutPage: React.FC = () => {
   const editor = useOptionalEditor();
   const lang = useRouteLanguage();
   const credits: AboutCreditsData = editorial?.about.credits ?? defaultAboutCredits;
+  const canEditSite = Boolean(editor?.enabled && editor.canEditEditorial());
 
   const commitCredits = (next: AboutCreditsData) => {
-    if (editor?.enabled) void editor.commitAboutCredits(next);
+    if (canEditSite) void editor.commitAboutCredits(next);
   };
 
   const patchGroupPeople = (groupId: string, people: string[]) => {
@@ -40,7 +41,7 @@ const AboutPage: React.FC = () => {
           
           {/* Hero Title */}
           <header className="mb-12">
-            {editor?.enabled ? (
+            {canEditSite ? (
               <InlineEditableText
                 as="h1"
                 size="lg"
@@ -64,7 +65,7 @@ const AboutPage: React.FC = () => {
 
           {/* Main Copy */}
           <section className="space-y-12">
-            {editor?.enabled ? (
+            {canEditSite ? (
               <div className="text-2xl md:text-3xl font-['Space_Grotesk'] font-light leading-snug tracking-tight text-white">
                 <InlineEditableText
                   multiline
@@ -79,12 +80,12 @@ const AboutPage: React.FC = () => {
                 />
               </div>
             ) : (
-              <p className="text-2xl md:text-3xl font-['Space_Grotesk'] font-light leading-snug tracking-tight text-white">
+              <p className="whitespace-pre-wrap text-2xl md:text-3xl font-['Space_Grotesk'] font-light leading-snug tracking-tight text-white">
                 {resolveEditorialText(editorial?.about.lead, lang)}
               </p>
             )}
             <div className="text-lg space-y-8 text-[#c6c6c6] font-['Inter'] leading-relaxed">
-              {editor?.enabled ? (
+              {canEditSite ? (
                 <>
                   <div>
                     <InlineEditableText
@@ -115,10 +116,10 @@ const AboutPage: React.FC = () => {
                 </>
               ) : (
                 <>
-                  <p>
+                  <p className="whitespace-pre-wrap">
                     {resolveEditorialText(editorial?.about.paragraph1, lang)}
                   </p>
-                  <p>
+                  <p className="whitespace-pre-wrap">
                     {resolveEditorialText(editorial?.about.paragraph2, lang)}
                   </p>
                 </>
@@ -129,7 +130,7 @@ const AboutPage: React.FC = () => {
           {/* Credits Section with production data */}
           <footer className="mt-24 pt-12 border-t border-[#474747]/20">
             <div className="flex items-end justify-between gap-6 mb-10">
-              {editor?.enabled ? (
+              {canEditSite ? (
                 <>
                   <InlineEditableText
                     as="h2"
@@ -181,7 +182,7 @@ const AboutPage: React.FC = () => {
                     group.id === 'voiceovers' ? 'md:col-span-2' : ''
                   }`}
                 >
-                  {editor?.enabled ? (
+                  {canEditSite ? (
                     <InlineEditableText
                       as="h3"
                       size="sm"
@@ -214,7 +215,7 @@ const AboutPage: React.FC = () => {
                   )}
                   <div className="flex flex-wrap items-center gap-2">
                     {group.people.map((person, idx) =>
-                      editor?.enabled ? (
+                      canEditSite ? (
                         <EditableStringListItem
                           key={`${group.id}-${idx}`}
                           value={person}
@@ -243,7 +244,7 @@ const AboutPage: React.FC = () => {
                         </span>
                       )
                     )}
-                    {editor?.enabled ? (
+                    {canEditSite ? (
                       <button
                         type="button"
                         onClick={() =>
@@ -261,7 +262,7 @@ const AboutPage: React.FC = () => {
             </div>
 
             <section className="mt-10 border border-white/10 bg-black/30 p-6 md:p-7">
-              {editor?.enabled ? (
+              {canEditSite ? (
                 <InlineEditableText
                   as="h3"
                   size="sm"
@@ -290,7 +291,7 @@ const AboutPage: React.FC = () => {
               )}
               <div className="flex flex-wrap items-center gap-2">
                 {credits.collaborators.map((name, idx) =>
-                  editor?.enabled ? (
+                  canEditSite ? (
                     <EditableStringListItem
                       key={`collab-${idx}`}
                       value={name}
@@ -316,7 +317,7 @@ const AboutPage: React.FC = () => {
                     </span>
                   )
                 )}
-                {editor?.enabled ? (
+                {canEditSite ? (
                   <button
                     type="button"
                     onClick={() => patchCollaborators([...credits.collaborators, 'Nuevo nombre'])}
@@ -327,7 +328,7 @@ const AboutPage: React.FC = () => {
                   </button>
                 ) : null}
               </div>
-              {editor?.enabled ? (
+              {canEditSite ? (
                 <div className="mt-5 text-base leading-relaxed text-[#c6c6c6]">
                   <InlineEditableText
                     multiline
@@ -350,7 +351,7 @@ const AboutPage: React.FC = () => {
                   />
                 </div>
               ) : (
-                <p className="mt-5 text-base leading-relaxed text-[#c6c6c6]">
+                <p className="mt-5 whitespace-pre-wrap text-base leading-relaxed text-[#c6c6c6]">
                   {resolveEditorialText(credits.collaboratorsNote, lang)}
                 </p>
               )}

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useTranslation } from '../hooks/useTranslation';
+import { useOptionalEditor } from '../contexts/EditorContext';
+import { devEditorService, type AdminEditorUser } from '../services/devEditorService';
+import { getSupabaseClient } from '../lib/supabaseClient';
+import { FormButton, FormContainer, FormField, FormInput } from '../components/ui/FormComponents';
+import { env } from '../config/env';
+
+type ProgramOption = { id: string; title: string };
+
+const AdminUsersPage: React.FC = () => {
+  const { t } = useTranslation();
+  const editor = useOptionalEditor();
+  const [users, setUsers] = React.useState<AdminEditorUser[]>([]);
+  const [programs, setPrograms] = React.useState<ProgramOption[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [message, setMessage] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const [newEmail, setNewEmail] = React.useState('');
+  const [newPassword, setNewPassword] = React.useState('');
+  const [newRole, setNewRole] = React.useState<'admin' | 'editor'>('editor');
+  const [newProgramId, setNewProgramId] = React.useState('');
+
+  const loadUsers = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await devEditorService.listAdminUsers();
+      setUsers(res.users ?? []);
+      setMessage(res.message);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al cargar usuarios.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!editor?.isAdmin) return;
+    void loadUsers();
+  }, [editor?.isAdmin, loadUsers]);
+
+  React.useEffect(() => {
+    if (!editor?.isAdmin) return;
+    const supabase = getSupabaseClient();
+    if (!supabase) return;
+    void supabase
+      .from('content_items')
+      .select('id, content_kind')
+      .eq('content_kind', 'program')
+      .then(async ({ data, error: itemsError }) => {
+        if (itemsError || !data?.length) return;
+        const ids = data.map((row) => row.id as string);
+        const { data: translations } = await supabase
+          .from('content_item_translations')
+          .select('content_item_id, title, lang')
+          .in('content_item_id', ids)
+          .eq('lang', env.DEFAULT_LANGUAGE);
+        const titleById = new Map(
+          (translations ?? []).map((row) => [String(row.content_item_id), String(row.title)])
+        );
+        setPrograms(
+          ids.map((id) => ({
+            id,
+            title: titleById.get(id) || id,
+          }))
+        );
+      });
+  }, [editor?.isAdmin]);
+
+  if (!editor?.authenticated) {
+    return <Navigate to="/editor-login" replace />;
+  }
+
+  if (!editor.isAdmin) {
+    return <Navigate to={`/${env.DEFAULT_LANGUAGE}`} replace />;
+  }
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await devEditorService.createAdminUser({
+        email: newEmail.trim(),
+        password: newPassword,
+        role: newRole,
+        programId: newRole === 'editor' ? newProgramId : null,
+      });
+      setMessage(res.message);
+      setNewEmail('');
+      setNewPassword('');
+      setNewProgramId('');
+      await loadUsers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo crear el usuario.');
+    }
+  };
+
+  const handleToggleDisabled = async (user: AdminEditorUser) => {
+    setError(null);
+    try {
+      const res = await devEditorService.updateAdminUser({
+        userId: user.userId,
+        disabled: !user.disabledAt,
+      });
+      setMessage(res.message);
+      await loadUsers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo actualizar el usuario.');
+    }
+  };
+
+  const handleAssignProgram = async (user: AdminEditorUser, programId: string) => {
+    setError(null);
+    try {
+      const res = await devEditorService.updateAdminUser({
+        userId: user.userId,
+        role: 'editor',
+        programId: programId || null,
+      });
+      setMessage(res.message);
+      await loadUsers();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo asignar el programa.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-black px-4 py-10 text-white md:px-8">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="font-['Space_Grotesk'] text-2xl font-bold tracking-tight md:text-3xl">
+          {t('admin-users.title')}
+        </h1>
+        <p className="mt-2 font-mono text-xs uppercase tracking-[0.2em] text-white/50">
+          {t('admin-users.subtitle')}
+        </p>
+
+        {message ? <p className="mt-4 text-sm text-lime-300/90">{message}</p> : null}
+        {error ? <p className="mt-4 text-sm text-red-300">{error}</p> : null}
+
+        <section className="glass-card mt-8 p-6">
+          <h2 className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/60">
+            {t('admin-users.create-title')}
+          </h2>
+          <FormContainer onSubmit={handleCreate} className="mt-4">
+            <FormField label={t('admin-users.email')} required>
+              <FormInput
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                disabled={loading}
+              />
+            </FormField>
+            <FormField label={t('admin-users.password')} required>
+              <FormInput
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                disabled={loading}
+              />
+            </FormField>
+            <FormField label={t('admin-users.role')} required>
+              <select
+                value={newRole}
+                onChange={(e) => setNewRole(e.target.value as 'admin' | 'editor')}
+                className="w-full border border-white/20 bg-black/50 px-3 py-2 text-sm text-white"
+              >
+                <option value="editor">{t('admin-users.role-editor')}</option>
+                <option value="admin">{t('admin-users.role-admin')}</option>
+              </select>
+            </FormField>
+            {newRole === 'editor' ? (
+              <FormField label={t('admin-users.program')} required>
+                <select
+                  value={newProgramId}
+                  onChange={(e) => setNewProgramId(e.target.value)}
+                  className="w-full border border-white/20 bg-black/50 px-3 py-2 text-sm text-white"
+                >
+                  <option value="">{t('admin-users.program-placeholder')}</option>
+                  {programs.map((program) => (
+                    <option key={program.id} value={program.id}>
+                      {program.title} ({program.id})
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+            ) : null}
+            <FormButton type="submit" loading={loading}>
+              {t('admin-users.create-submit')}
+            </FormButton>
+          </FormContainer>
+        </section>
+
+        <section className="mt-8 overflow-x-auto border border-white/15">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-white/15 bg-white/5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/55">
+              <tr>
+                <th className="px-4 py-3">{t('admin-users.col-email')}</th>
+                <th className="px-4 py-3">{t('admin-users.col-role')}</th>
+                <th className="px-4 py-3">{t('admin-users.col-program')}</th>
+                <th className="px-4 py-3">{t('admin-users.col-status')}</th>
+                <th className="px-4 py-3">{t('admin-users.col-actions')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr key={user.userId} className="border-b border-white/10">
+                  <td className="px-4 py-3">{user.email || user.userId}</td>
+                  <td className="px-4 py-3 uppercase">{user.role}</td>
+                  <td className="px-4 py-3">
+                    {user.role === 'editor' ? (
+                      <select
+                        value={user.programId ?? ''}
+                        onChange={(e) => void handleAssignProgram(user, e.target.value)}
+                        className="max-w-[12rem] border border-white/20 bg-black/50 px-2 py-1 text-xs"
+                      >
+                        <option value="">{t('admin-users.program-placeholder')}</option>
+                        {programs.map((program) => (
+                          <option key={program.id} value={program.id}>
+                            {program.id}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {user.disabledAt ? t('admin-users.status-disabled') : t('admin-users.status-active')}
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => void handleToggleDisabled(user)}
+                      className="border border-white/30 px-2 py-1 font-mono text-[10px] uppercase tracking-wider hover:bg-white/10"
+                    >
+                      {user.disabledAt
+                        ? t('admin-users.action-enable')
+                        : t('admin-users.action-disable')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {!loading && users.length === 0 ? (
+            <p className="px-4 py-6 text-center text-white/50">{t('admin-users.empty')}</p>
+          ) : null}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default AdminUsersPage;

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -18,6 +18,7 @@ const ContactPage = () => {
     resolveEditorialText(editorial?.contact.pageTitle, lang) || t('contact.page-title');
   const pageSubtitle =
     resolveEditorialText(editorial?.contact.pageSubtitle, lang) || t('contact.page-subtitle');
+  const canEditSite = Boolean(editor?.enabled && editor.canEditEditorial());
 
   return (
     <section className="relative min-h-full bg-black px-3 pb-16 pt-24 text-white md:px-6">
@@ -25,7 +26,7 @@ const ContactPage = () => {
 
       <div className="relative z-10 mx-auto w-full max-w-2xl">
         <header className="mb-10">
-          {editor?.enabled ? (
+          {canEditSite ? (
             <InlineEditableText
               as="h1"
               size="lg"
@@ -45,7 +46,7 @@ const ContactPage = () => {
               {pageTitle}
             </h1>
           )}
-          {editor?.enabled ? (
+          {canEditSite ? (
             <InlineEditableText
               as="div"
               className="mt-4"

--- a/src/pages/EditorLoginPage.tsx
+++ b/src/pages/EditorLoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { env } from '../config/env';
 import { getSupabaseClient, isEditorAvailable } from '../lib/supabaseClient';
+import { fetchEditorProfile } from '../services/editorProfileService';
 import { FormContainer, FormField, FormInput, FormButton } from '../components/ui/FormComponents';
 import { FALLBACK_LOGO } from '../hooks/useLiveProgram';
 
@@ -45,6 +46,23 @@ const EditorLoginPage: React.FC = () => {
       if (signInError) {
         setError(signInError.message || 'Credenciales inválidas.');
         setPassword('');
+        return;
+      }
+      const profile = await fetchEditorProfile();
+      if (!profile) {
+        await supabase.auth.signOut();
+        setError('No tenés perfil de editor. Contactá a un administrador.');
+        return;
+      }
+      if (profile.disabledAt) {
+        await supabase.auth.signOut();
+        setError('Tu cuenta de editor está desactivada.');
+        return;
+      }
+      if (profile.role === 'editor' && profile.programId) {
+        navigate(`/${env.DEFAULT_LANGUAGE}/programacion/${encodeURIComponent(profile.programId)}`, {
+          replace: true,
+        });
         return;
       }
       navigate(`/${env.DEFAULT_LANGUAGE}`, { replace: true });

--- a/src/pages/EpisodeDetailPage.tsx
+++ b/src/pages/EpisodeDetailPage.tsx
@@ -119,22 +119,25 @@ const EpisodeDetailPage: React.FC = () => {
   }, [contentIndex, contentLang, routeProgramId, editor?.enabled]);
 
   const archiveProgramId = program?.id ?? '';
+  const canEditThisProgram = Boolean(
+    editor?.enabled && program?.id && editor.canEditProgram(program.id)
+  );
 
   const { data: archiveData, isLoading, isError } = useQuery({
     queryKey: ['program-episodes', archiveProgramId, contentLang],
     queryFn: () => episodeService.getEpisodesByProgram(archiveProgramId, contentLang),
-    enabled: Boolean(program?.id) && !editor?.enabled,
+    enabled: Boolean(program?.id) && !canEditThisProgram,
   });
 
   React.useEffect(() => {
-    if (editor?.enabled && archiveProgramId) {
+    if (canEditThisProgram && archiveProgramId) {
       void editor.loadEpisodes(archiveProgramId);
     }
-  }, [archiveProgramId, editor?.enabled, editor?.loadEpisodes]);
+  }, [archiveProgramId, canEditThisProgram, editor?.loadEpisodes]);
 
   const activeArchiveData = React.useMemo(() => {
     if (!archiveProgramId) return archiveData;
-    if (editor?.enabled && editor.episodesByProgram[archiveProgramId]) {
+    if (canEditThisProgram && editor.episodesByProgram[archiveProgramId]) {
       return editor.episodesByProgram[archiveProgramId];
     }
     return archiveData;
@@ -220,7 +223,7 @@ const EpisodeDetailPage: React.FC = () => {
     episode.date,
     isProgramScheduleMeta(program.schedule_meta) ? program.schedule_meta : null
   );
-  if (!released && !editor?.enabled) {
+  if (!released && !canEditThisProgram) {
     return (
       <div className="flex min-h-[calc(100dvh-5rem)] flex-col items-center justify-center bg-black px-6 text-center">
         <p className="font-['Space_Grotesk'] text-[10px] uppercase tracking-[0.2em] text-white/40">
@@ -255,7 +258,7 @@ const EpisodeDetailPage: React.FC = () => {
     : program.schedule;
   const episodeTags = (episode.tags ?? []).map((tag) => tag.trim()).filter(Boolean);
   const commitEpisodeCollaborators = (nextCollaborators: string[]) =>
-    editor?.enabled
+    canEditThisProgram
       ? editor.commitEpisodeField(
           program.id,
           episode.id,
@@ -264,7 +267,7 @@ const EpisodeDetailPage: React.FC = () => {
         )
       : Promise.resolve();
   const commitEpisodeTags = (nextTags: string[]) =>
-    editor?.enabled
+    canEditThisProgram
       ? editor.commitEpisodeField(
           program.id,
           episode.id,
@@ -274,7 +277,7 @@ const EpisodeDetailPage: React.FC = () => {
       : Promise.resolve();
 
   const handleUploadEpisodeAudio = async (file: File) => {
-    if (!editor?.enabled || !program || !episode) return;
+    if (!canEditThisProgram || !program || !episode) return;
     const mimeType = file.type || 'audio/mpeg';
     if (!mimeType.startsWith('audio/') && !/\.(wav|flac|mp3|m4a)$/i.test(file.name)) {
       setUploadMessage('Selecciona un archivo de audio válido.');
@@ -325,7 +328,7 @@ const EpisodeDetailPage: React.FC = () => {
               </span>
             </nav>
 
-            {editor?.enabled ? (
+            {canEditThisProgram ? (
               <InlineEditableText
                 as="h1"
                 size="lg"
@@ -341,7 +344,7 @@ const EpisodeDetailPage: React.FC = () => {
             )}
 
             <div className="mt-4 inline-flex max-w-full flex-wrap items-center gap-2 font-mono text-xs uppercase tracking-[0.2em] text-white/50">
-              {editor?.enabled ? (
+              {canEditThisProgram ? (
                 <InlineEditableText
                   as="span"
                   className="!w-auto"
@@ -362,7 +365,7 @@ const EpisodeDetailPage: React.FC = () => {
               <span className="text-white/25">·</span>
               <span>{t('episode-detail.duration')}</span>
               <span className="text-white/25">:</span>
-              {editor?.enabled ? (
+              {canEditThisProgram ? (
                 <InlineEditableText
                   as="span"
                   className="!w-auto"
@@ -374,12 +377,12 @@ const EpisodeDetailPage: React.FC = () => {
               )}
             </div>
 
-            {(editor?.enabled || episodeTags.length > 0) && (
+            {(canEditThisProgram || episodeTags.length > 0) && (
               <div className="mt-6 max-w-2xl">
                 <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-white/40">
                   Tags
                 </p>
-                {editor?.enabled ? (
+                {canEditThisProgram ? (
                   <div className="mt-2 inline-flex flex-wrap items-center gap-1.5">
                     {episodeTags.map((tag, idx) => (
                       <EditableStringListItem
@@ -455,7 +458,7 @@ const EpisodeDetailPage: React.FC = () => {
               {talentLine && (
                 <p className="mt-1 font-mono text-xs text-white/50 whitespace-nowrap">
                   {t('program-detail.with')}{' '}
-                  {editor?.enabled ? (
+                  {canEditThisProgram ? (
                     <span className="inline-flex flex-wrap items-center gap-1.5 align-middle whitespace-normal">
                       {effectiveCollaborators.map((person, idx) => (
                         <EditableStringListItem
@@ -490,15 +493,15 @@ const EpisodeDetailPage: React.FC = () => {
                   )}
                 </p>
               )}
-              {(editor?.enabled || episodeDescription) && (
+              {(canEditThisProgram || episodeDescription) && (
                 <div className="mt-4 max-w-2xl">
-                  {editor?.enabled ? (
+                  {canEditThisProgram ? (
                     <p className="font-mono text-[10px] text-white/35">
                       {t('episode-detail.description-placeholder')}
                     </p>
                   ) : null}
-                  <div className="mt-2 font-['Space_Grotesk'] text-sm leading-relaxed text-white/75 md:text-base">
-                    {editor?.enabled ? (
+                  <div className="mt-2 whitespace-pre-wrap font-['Space_Grotesk'] text-sm leading-relaxed text-white/75 md:text-base">
+                    {canEditThisProgram ? (
                       <InlineEditableText
                         value={episode.description ?? ''}
                         multiline
@@ -547,7 +550,7 @@ const EpisodeDetailPage: React.FC = () => {
             className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-black/20 lg:bg-gradient-to-l"
             aria-hidden
           />
-          {editor?.enabled && (
+          {canEditThisProgram && (
             <div className="absolute bottom-4 right-4 z-20 flex w-[min(100%,24rem)] flex-col gap-2 drop-shadow-lg">
               <EditableImageField
                 label="Portada del episodio"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -153,7 +153,8 @@ const HomePage = () => {
   const hasCustomHomeHero =
     defaultHeroValue !== '' && defaultHeroValue !== DEFAULT_PROGRAM_LOGO;
 
-  const homeHeroEditor = editor?.enabled ? (
+  const canEditSite = Boolean(editor?.enabled && editor.canEditEditorial());
+  const homeHeroEditor = canEditSite ? (
     <div className="absolute left-3 top-14 z-20 w-[min(100%,19rem)] md:left-4 md:top-20">
       <EditableImageField
         label="Imagen del home (sin programa en vivo)"
@@ -339,7 +340,7 @@ const HomePage = () => {
           <div className="absolute inset-0 bg-black/70" aria-hidden />
 
           <div className="relative z-10 mx-auto flex min-h-[42vh] w-full max-w-5xl flex-col items-center justify-center px-6 py-16 text-center">
-            {editor?.enabled ? (
+            {canEditSite ? (
               <InlineEditableText
                 as="p"
                 align="center"
@@ -357,7 +358,7 @@ const HomePage = () => {
                 {manifestKicker}
               </p>
             )}
-            {editor?.enabled ? (
+            {canEditSite ? (
               <InlineEditableText
                 as="h3"
                 size="lg"
@@ -377,7 +378,7 @@ const HomePage = () => {
                 {manifestTitle}
               </h3>
             )}
-            {editor?.enabled ? (
+            {canEditSite ? (
               <InlineEditableText
                 as="div"
                 className="mt-5 max-w-2xl"

--- a/src/pages/ProgramDetailPage.tsx
+++ b/src/pages/ProgramDetailPage.tsx
@@ -153,6 +153,10 @@ const ProgramDetailPage: React.FC = () => {
   }, [contentIndex, contentLang, programId, editor?.enabled]);
 
   const isEvent = program ? isCalendarEventEntry(program) : false;
+  const canEditThisProgram = Boolean(
+    canEditThisProgram && program?.id && editor.canEditProgram(program.id)
+  );
+  const canManagePrograms = Boolean(editor?.enabled && editor.canManagePrograms());
   const logoSrc = program?.logo ? resolveProgramLogoSrc(program.logo) : null;
 
   useEffect(() => {
@@ -173,7 +177,7 @@ const ProgramDetailPage: React.FC = () => {
 
   const excerpt = useMemo(() => {
     if (!program?.content) return null;
-    const text = program.content.replace(/\s+/g, ' ').trim();
+    const text = program.content.trim();
     if (!text) return null;
     return text.length > 240 ? `${text.slice(0, 237)}…` : text;
   }, [program]);
@@ -242,19 +246,19 @@ const ProgramDetailPage: React.FC = () => {
   const { data: archiveData, isLoading: archiveLoading, isError: archiveError } = useQuery({
     queryKey: ['program-episodes', archiveProgramId, contentLang],
     queryFn: () => episodeService.getEpisodesByProgram(archiveProgramId, contentLang),
-    enabled: Boolean(program?.id) && !editor?.enabled,
+    enabled: Boolean(program?.id) && !canEditThisProgram,
   });
 
   React.useEffect(() => {
-    if (editor?.enabled && archiveProgramId) {
+    if (canEditThisProgram && archiveProgramId) {
       void editor.loadEpisodes(archiveProgramId);
     }
-  }, [archiveProgramId, editor?.enabled, editor?.loadEpisodes]);
+  }, [archiveProgramId, canEditThisProgram, editor?.loadEpisodes]);
 
   const activeArchiveData = React.useMemo(() => {
     if (!archiveProgramId) return archiveData;
     const editorProgramEpisodes = editor?.episodesByProgram[archiveProgramId];
-    if (editor?.enabled && editorProgramEpisodes) {
+    if (canEditThisProgram && editorProgramEpisodes) {
       const hasEditorEpisodes = editorProgramEpisodes.episodes.length > 0;
       const hasArchiveEpisodes = (archiveData?.episodes.length ?? 0) > 0;
       if (hasEditorEpisodes || !hasArchiveEpisodes) {
@@ -271,16 +275,16 @@ const ProgramDetailPage: React.FC = () => {
   const sortedTrashEpisodes = useMemo(
     () =>
       sortEpisodesChronologicallyDesc(
-        editor?.enabled ? editor.episodesTrashByProgram[archiveProgramId]?.episodes ?? [] : []
+        canEditThisProgram ? editor.episodesTrashByProgram[archiveProgramId]?.episodes ?? [] : []
       ),
     [archiveProgramId, editor]
   );
   const visibleEpisodes = useMemo(() => {
-    if (import.meta.env.DEV || editor?.enabled) return sortedEpisodes;
+    if (import.meta.env.DEV || canEditThisProgram) return sortedEpisodes;
     return sortedEpisodes.filter((ep) =>
       isEpisodeReleased(ep.date, scheduleMeta)
     );
-  }, [editor?.enabled, sortedEpisodes, scheduleMeta]);
+  }, [canEditThisProgram, sortedEpisodes, scheduleMeta]);
 
   const dateFormatter = useMemo(
     () =>
@@ -294,7 +298,7 @@ const ProgramDetailPage: React.FC = () => {
 
   if (!program) return <NotFound />;
 
-  const programImageEditor = editor?.enabled ? (
+  const programImageEditor = canEditThisProgram ? (
     <div className="absolute right-2 top-14 z-20 w-[min(100%,19rem)] md:right-4 md:top-20">
       <EditableImageField
         label="Imagen del programa"
@@ -322,7 +326,7 @@ const ProgramDetailPage: React.FC = () => {
   };
 
   const handleDeleteProgram = async () => {
-    if (!editor?.enabled) return;
+    if (!canManagePrograms) return;
     const ok = await editor.deleteProgram({
       id: program.id,
       confirmText: deleteConfirm.trim(),
@@ -335,7 +339,7 @@ const ProgramDetailPage: React.FC = () => {
   };
 
   const handlePurgeEpisode = () => {
-    if (!editor?.enabled || !episodeToPurge) return;
+    if (!canEditThisProgram || !episodeToPurge) return;
     void editor.purgeEpisode(program.id, episodeToPurge.id);
     setPurgeConfirmOpen(false);
     setEpisodeToPurge(null);
@@ -358,7 +362,7 @@ const ProgramDetailPage: React.FC = () => {
   };
 
   const saveScheduleEditor = async () => {
-    if (!editor?.enabled || !scheduleDraft) return;
+    if (!canEditThisProgram || !scheduleDraft) return;
     const legacy = scheduleMetaToLegacyString(scheduleDraft);
     await editor.commitMultipleContentFieldsAllLanguages(program.id, {
       schedule_meta: scheduleDraft,
@@ -368,7 +372,7 @@ const ProgramDetailPage: React.FC = () => {
   };
 
   const handleCreateEpisodeWithAudio = async () => {
-    if (!editor?.enabled || !newEpisodeFile) return;
+    if (!canEditThisProgram || !newEpisodeFile) return;
     if (!newEpisodeTitle.trim()) {
       setCreateEpisodeMessage('El título es obligatorio.');
       return;
@@ -422,7 +426,7 @@ const ProgramDetailPage: React.FC = () => {
   };
 
   const commitTalentList = (nextTalent: string[]) =>
-    editor?.enabled
+    canEditThisProgram
       ? editor.commitContentFieldAllLanguages(
           program.id,
           'talent',
@@ -431,7 +435,7 @@ const ProgramDetailPage: React.FC = () => {
       : Promise.resolve();
 
   const commitSocialList = (nextSocial: string[]) =>
-    editor?.enabled
+    canEditThisProgram
       ? editor.commitContentFieldAllLanguages(
           program.id,
           'social',
@@ -450,7 +454,7 @@ const ProgramDetailPage: React.FC = () => {
           <span className="mx-2 text-[var(--program-accent-mid)]">—</span>
           <span className="inline-flex items-center gap-2 text-white/70">
             <span>{scheduleLocalized}</span>
-            {editor?.enabled ? (
+            {canEditThisProgram ? (
               <button
                 type="button"
                 onClick={openScheduleEditor}
@@ -463,7 +467,7 @@ const ProgramDetailPage: React.FC = () => {
           </span>
         </p>
       )}
-      {editor?.enabled && showScheduleEditor ? (
+      {canEditThisProgram && showScheduleEditor ? (
         <div className="mt-3 grid max-w-xl grid-cols-1 gap-2 border border-white/15 bg-black/40 p-3 md:grid-cols-4">
           <select
             className="border border-white/20 bg-black px-2 py-1 text-xs"
@@ -533,7 +537,7 @@ const ProgramDetailPage: React.FC = () => {
         </div>
       ) : null}
 
-      {editor?.enabled ? (
+      {canEditThisProgram ? (
         <InlineEditableText
           as="h1"
           size="lg"
@@ -559,12 +563,12 @@ const ProgramDetailPage: React.FC = () => {
         </h1>
       )}
 
-      {(talentLine || editor?.enabled) && (
+      {(talentLine || canEditThisProgram) && (
         <p className="mt-4 font-mono text-xs leading-relaxed text-white/55 whitespace-nowrap md:text-sm">
           <span className="text-[var(--program-accent)]">{t('program-detail.with')}</span>
           <span className="text-white/75 whitespace-nowrap">
             {' '}
-            {editor?.enabled ? (
+            {canEditThisProgram ? (
               <span className="inline-flex flex-wrap items-center gap-1.5 align-middle whitespace-normal">
                 {(program.talent ?? []).map((person, idx) => (
                   <EditableStringListItem
@@ -599,9 +603,9 @@ const ProgramDetailPage: React.FC = () => {
         </p>
       )}
 
-      {(socialHandles.length > 0 || editor?.enabled) && (
+      {(socialHandles.length > 0 || canEditThisProgram) && (
         <p className="mt-2 font-mono text-[11px] tracking-[0.08em] text-white/35">
-          {editor?.enabled ? (
+          {canEditThisProgram ? (
             <span className="inline-flex flex-wrap items-center gap-1.5 align-middle">
               {socialHandles.map((handle, idx) => (
                 <EditableStringListItem
@@ -647,11 +651,11 @@ const ProgramDetailPage: React.FC = () => {
         </p>
       )}
 
-      {(editor?.enabled || excerpt) && (
+      {(canEditThisProgram || excerpt) && (
         <div className="mt-8 max-w-2xl border-l-2 border-[var(--program-accent)] pl-5">
           <p className="mb-1.5 font-mono text-[9px] uppercase tracking-[0.32em] text-[var(--program-accent-soft)]">
           </p>
-          {editor?.enabled ? (
+          {canEditThisProgram ? (
             <InlineEditableText
               value={program.content ?? ''}
               multiline
@@ -668,7 +672,7 @@ const ProgramDetailPage: React.FC = () => {
               }
             />
           ) : (
-            <p className="line-clamp-4 font-['Space_Grotesk'] text-sm italic leading-relaxed text-white/70 md:text-base">
+            <p className="line-clamp-4 whitespace-pre-wrap font-['Space_Grotesk'] text-sm italic leading-relaxed text-white/70 md:text-base">
               {excerpt}
             </p>
           )}
@@ -686,7 +690,7 @@ const ProgramDetailPage: React.FC = () => {
         >
           {t('program-detail.back')}
         </Link>
-        {editor?.enabled ? (
+        {canEditThisProgram ? (
           <button
             type="button"
             onClick={() => setDeleteOpen(true)}
@@ -744,7 +748,7 @@ const ProgramDetailPage: React.FC = () => {
           <h2 className="mt-2 font-['Space_Grotesk'] text-2xl font-bold uppercase tracking-tight text-white md:text-4xl">
             {t('program-detail.archive-title')}
           </h2>
-          {editor?.enabled ? (
+          {canEditThisProgram ? (
             <div className="mt-4">
               <div className="flex flex-wrap items-center gap-2">
                 <button
@@ -892,7 +896,7 @@ const ProgramDetailPage: React.FC = () => {
                           ))}
                         </div>
                       )}
-                      {editor?.enabled ? (
+                      {canEditThisProgram ? (
                         <div className="mt-4">
                           <button
                             type="button"

--- a/src/pages/ProgramPage.tsx
+++ b/src/pages/ProgramPage.tsx
@@ -77,6 +77,14 @@ const ProgramPage: React.FC = () => {
         if (!editor?.enabled && !isArchivosProgramEntry(entry)) {
           return null;
         }
+        if (
+          editor?.enabled &&
+          !editor.isAdmin &&
+          editor.assignedProgramId &&
+          (entry.id || key) !== editor.assignedProgramId
+        ) {
+          return null;
+        }
         return {
           ...entry,
           id: entry.id || key,
@@ -85,7 +93,7 @@ const ProgramPage: React.FC = () => {
         };
       })
       .filter((entry): entry is ShowData => entry !== null);
-  }, [contentIndex, contentLang, editor?.enabled]);
+  }, [contentIndex, contentLang, editor?.enabled, editor?.isAdmin, editor?.assignedProgramId]);
 
   const orderedShows = useMemo(() => {
     return [...allShows].sort((a, b) => {
@@ -173,7 +181,7 @@ const ProgramPage: React.FC = () => {
           <h1 className={`${PAGE_SCREEN_TITLE_CLASS} leading-none text-white`}>
             {t('programs.page-title')}
           </h1>
-          {editor?.enabled ? (
+          {editor?.enabled && editor.canManagePrograms() ? (
             <button
               type="button"
               onClick={() => setCreateOpen(true)}

--- a/src/services/devEditorService.ts
+++ b/src/services/devEditorService.ts
@@ -49,6 +49,22 @@ export interface UploadEpisodeAudioToArchiveResponse {
   fileName?: string;
 }
 
+export interface AdminEditorUser {
+  userId: string;
+  email: string;
+  role: 'admin' | 'editor';
+  programId: string | null;
+  disabledAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminListUsersResponse {
+  ok: boolean;
+  message: string;
+  users: AdminEditorUser[];
+}
+
 export interface TranslateTextResponse {
   ok: boolean;
   message: string;
@@ -157,6 +173,41 @@ export class DevEditorService {
     }
 
     return parseJson<UploadEpisodeAudioToArchiveResponse>(response);
+  }
+
+  public async listAdminUsers(): Promise<AdminListUsersResponse> {
+    return requestJson('/__dev/editor/admin/list-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+  }
+
+  public async createAdminUser(payload: {
+    email: string;
+    password: string;
+    role: 'admin' | 'editor';
+    programId?: string | null;
+  }): Promise<{ ok: boolean; message: string }> {
+    return requestJson('/__dev/editor/admin/create-user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }
+
+  public async updateAdminUser(payload: {
+    userId: string;
+    role?: 'admin' | 'editor';
+    programId?: string | null;
+    disabled?: boolean;
+    password?: string;
+  }): Promise<{ ok: boolean; message: string }> {
+    return requestJson('/__dev/editor/admin/update-user', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
   }
 
   public async translateText(payload: {

--- a/src/services/editorProfileService.ts
+++ b/src/services/editorProfileService.ts
@@ -1,0 +1,60 @@
+import { getSupabaseClient } from '../lib/supabaseClient';
+
+export type EditorRole = 'admin' | 'editor';
+
+export interface EditorProfile {
+  userId: string;
+  role: EditorRole;
+  programId: string | null;
+  disabledAt: string | null;
+}
+
+type EditorProfileRow = {
+  user_id: string;
+  role: EditorRole;
+  program_id: string | null;
+  disabled_at: string | null;
+};
+
+export const fetchEditorProfile = async (): Promise<EditorProfile | null> => {
+  const supabase = getSupabaseClient();
+  if (!supabase) return null;
+
+  const { data: sessionData } = await supabase.auth.getSession();
+  const userId = sessionData.session?.user?.id;
+  if (!userId) return null;
+
+  const { data, error } = await supabase
+    .from('editor_profiles')
+    .select('user_id, role, program_id, disabled_at')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+
+  const row = data as EditorProfileRow;
+  if (row.role !== 'admin' && row.role !== 'editor') return null;
+
+  return {
+    userId: row.user_id,
+    role: row.role,
+    programId: row.program_id,
+    disabledAt: row.disabled_at,
+  };
+};
+
+export const canEditProgram = (
+  profile: EditorProfile | null,
+  programId: string
+): boolean => {
+  if (!profile || profile.disabledAt) return false;
+  if (profile.role === 'admin') return true;
+  return profile.role === 'editor' && profile.programId === programId;
+};
+
+export const canEditEditorial = (profile: EditorProfile | null): boolean =>
+  Boolean(profile && !profile.disabledAt && profile.role === 'admin');
+
+export const canManagePrograms = (profile: EditorProfile | null): boolean =>
+  canEditEditorial(profile);

--- a/src/services/supabaseContentService.ts
+++ b/src/services/supabaseContentService.ts
@@ -230,13 +230,20 @@ export const fetchEpisodesByProgramFromSupabase = async (
   return active;
 };
 
-export const fetchEditorContentIndexFromSupabase = async (): Promise<ContentIndexData | null> => {
+export const fetchEditorContentIndexFromSupabase = async (
+  options?: { programId?: string }
+): Promise<ContentIndexData | null> => {
   const supabase = getSupabaseClient();
   if (!supabase) return null;
 
+  let itemsQuery = supabase.from('content_items').select('*');
+  if (options?.programId) {
+    itemsQuery = itemsQuery.eq('id', options.programId);
+  }
+
   const [{ data: items, error: itemsError }, { data: translations, error: translationsError }] =
     await Promise.all([
-      supabase.from('content_items').select('*'),
+      itemsQuery,
       supabase.from('content_item_translations').select('*'),
     ]);
 
@@ -244,7 +251,12 @@ export const fetchEditorContentIndexFromSupabase = async (): Promise<ContentInde
   if (translationsError) throw new Error(translationsError.message);
   if (!items?.length) return null;
 
-  return buildContentIndex(items as ContentItemRow[], (translations ?? []) as TranslationRow[]);
+  const itemIds = new Set(items.map((item) => item.id));
+  const scopedTranslations = (translations ?? []).filter((row) =>
+    itemIds.has(row.content_item_id)
+  );
+
+  return buildContentIndex(items as ContentItemRow[], scopedTranslations as TranslationRow[]);
 };
 
 export const fetchTrashEpisodesByProgramFromSupabase = async (


### PR DESCRIPTION
## Summary
- Roles `admin` y `editor` con tabla `editor_profiles` y migración SQL
- Editores limitados a un programa; admins con acceso global
- Panel `/admin/usuarios` para crear usuarios y asignar programa
- RLS + validación en Cloudflare Functions

## Deploy checklist (prod)
- [ ] Migración SQL ya ejecutada en Supabase prod (`scripts/supabase-editor-roles-migration.sql`)
- [ ] Cloudflare Pages Functions: `SUPABASE_SERVICE_ROLE_KEY` (y `SUPABASE_URL` / `SUPABASE_ANON_KEY` si faltan)
- [ ] Merge este PR → deploy automático a prod

## Test plan
- [ ] Login admin: edita home y `/admin/usuarios`
- [ ] Login editor: solo su programa, sin editorial
- [ ] Editor no accede a programa ajeno