### PR TITLE
fix: redeploy editor roles (TDZ crash)

### DIFF
--- a/src/pages/ProgramDetailPage.tsx
+++ b/src/pages/ProgramDetailPage.tsx
@@ -154,7 +154,7 @@ const ProgramDetailPage: React.FC = () => {
 
   const isEvent = program ? isCalendarEventEntry(program) : false;
   const canEditThisProgram = Boolean(
-    canEditThisProgram && program?.id && editor.canEditProgram(program.id)
+    editor?.enabled && program?.id && editor.canEditProgram(program.id)
   );
   const canManagePrograms = Boolean(editor?.enabled && editor.canManagePrograms());
   const logoSrc = program?.logo ? resolveProgramLogoSrc(program.logo) : null;


### PR DESCRIPTION
## Summary
- Restores editor/admin RBAC from #66
- Fixes `ReferenceError: Cannot access before initialization` in ProgramDetailPage (`canEditThisProgram` referenced itself)

## Test plan
- [ ] Open any program detail page in prod (no white screen)
- [ ] Editor login still works