### PR TITLE
feat: Media Session now-playing and admin users UI polish

### DIFF
--- a/src/contexts/AudioContext.tsx
+++ b/src/contexts/AudioContext.tsx
@@ -4,6 +4,13 @@ import { STREAM_CONFIG } from '../constants/streamConstants';
 import { RadioStreamService } from '../services/streamService';
 import { AudioService, AudioValidationResult } from '../services/audioService';
 import { toast } from '../hooks/use-toast';
+import {
+  bindMediaSessionActionHandlers,
+  clearMediaSession,
+  parseNowPlayingTrack,
+  setMediaSessionPlaybackState,
+  updateMediaSessionMetadata,
+} from '../utils/mediaSession';
 
 interface AudioContextType {
   isPlaying: boolean;
@@ -106,6 +113,14 @@ export const AudioProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const audioInstancesRef = useRef<Set<HTMLAudioElement>>(new Set());
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
+  const isPlayingRef = useRef(isPlaying);
+  isPlayingRef.current = isPlaying;
+  const currentSourceRef = useRef(currentSource);
+  currentSourceRef.current = currentSource;
+  const mediaSessionHandlersRef = useRef<{ play: () => void; pause: () => void }>({
+    play: () => undefined,
+    pause: () => undefined,
+  });
   const streamService = useRef(
     new RadioStreamService(
       STREAM_CONFIG.statusUrl,
@@ -737,9 +752,11 @@ export const AudioProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   /**
    * Track Information - Following SRP
+   * Keep polling while audio is playing even if the tab is backgrounded,
+   * so iOS lock-screen metadata can update.
    */
   const fetchCurrentTrack = useCallback(async () => {
-    if (document.hidden) return;
+    if (document.hidden && !isPlayingRef.current) return;
     try {
       const trackName = await streamService.current.fetchCurrentTrack();
       if (trackName !== currentTrackRef.current) {
@@ -752,7 +769,7 @@ export const AudioProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }
   }, []);
 
-  // Polling del now-playing: solo con la pestaña visible
+  // Polling del now-playing: visible siempre; en background solo si está reproduciendo
   useEffect(() => {
     void fetchCurrentTrack();
 
@@ -761,7 +778,7 @@ export const AudioProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }, MEDIA_CONSTANTS.STREAM.UPDATE_INTERVAL);
 
     const onVisibilityChange = () => {
-      if (!document.hidden) void fetchCurrentTrack();
+      if (!document.hidden || isPlayingRef.current) void fetchCurrentTrack();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
@@ -771,12 +788,86 @@ export const AudioProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     };
   }, [fetchCurrentTrack]);
 
+  // Keep Media Session handlers pointing at the latest play/pause logic
+  mediaSessionHandlersRef.current = {
+    play: () => {
+      if (currentSourceRef.current === 'program' && programAudioRef.current) {
+        void AudioService.safePlay(programAudioRef.current).then((result) => {
+          if (result.success) {
+            setIsPlaying(true);
+            setError(null);
+          }
+        });
+        return;
+      }
+      if (!isPlayingRef.current) {
+        togglePlayWithPause();
+      }
+    },
+    pause: () => {
+      if (currentSourceRef.current === 'program' && programAudioRef.current) {
+        programAudioRef.current.pause();
+        setIsPlaying(false);
+        return;
+      }
+      if (isPlayingRef.current && currentSourceRef.current === 'radio' && audioRef.current) {
+        audioRef.current.pause();
+        setIsPlaying(false);
+      }
+    },
+  };
+
+  useEffect(() => {
+    return bindMediaSessionActionHandlers({
+      play: () => mediaSessionHandlersRef.current.play(),
+      pause: () => mediaSessionHandlersRef.current.pause(),
+    });
+  }, []);
+
+  // Push now-playing metadata to iOS Control Center / lock screen
+  useEffect(() => {
+    const hasActiveAudio =
+      (currentSource === 'radio' && Boolean(audioRef.current)) ||
+      (currentSource === 'program' && Boolean(programAudioRef.current));
+
+    if (!isPlaying && !hasActiveAudio) {
+      clearMediaSession();
+      return;
+    }
+
+    if (currentSource === 'program') {
+      updateMediaSessionMetadata({
+        title: currentProgramTitle || 'Programa',
+        artist: 'Radionudista',
+        album: 'Radionudista',
+        artworkUrl: coverImageUrl,
+      });
+    } else {
+      const { title, artist } = parseNowPlayingTrack(currentTrack);
+      updateMediaSessionMetadata({
+        title,
+        artist,
+        album: 'Radionudista',
+        artworkUrl: coverImageUrl,
+      });
+    }
+
+    setMediaSessionPlaybackState(isPlaying ? 'playing' : 'paused');
+  }, [
+    isPlaying,
+    currentSource,
+    currentTrack,
+    coverImageUrl,
+    currentProgramTitle,
+  ]);
+
   // Cleanup effect - ensures all audio instances are properly disposed on unmount
   useEffect(() => {
     return () => {
       if (import.meta.env.DEV) {
         console.log('AudioProvider unmounting - cleaning up all audio instances');
       }
+      clearMediaSession();
       cleanupAllAudioInstances();
     };
   }, [cleanupAllAudioInstances]);

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -409,7 +409,9 @@ const AdminUsersPage: React.FC = () => {
               : 'grid gap-5'
           }
         >
-          <section className={`flex min-h-0 flex-col ${panelShell}`}>
+          <section
+            className={`flex min-h-0 flex-col lg:min-h-[calc(100vh-12rem)] ${panelShell}`}
+          >
             <div className="flex items-center justify-between border-b border-white/10 px-4 py-3.5">
               <h2 className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.2em] text-white/55">
                 <Users className="h-4 w-4 text-white/50" aria-hidden />
@@ -419,7 +421,7 @@ const AdminUsersPage: React.FC = () => {
                 {users.length}
               </span>
             </div>
-            <div className="scrollbar-minimal flex max-h-[calc(100vh-12rem)] flex-col gap-2 overflow-y-auto p-3 pr-2">
+            <div className="scrollbar-minimal flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3 pr-2">
               {loading ? (
                 <p className="py-8 text-center text-sm text-white/45">{t('common.loading')}</p>
               ) : null}
@@ -444,20 +446,20 @@ const AdminUsersPage: React.FC = () => {
                 return (
                   <article
                     key={user.userId}
-                    className={`relative shrink-0 overflow-hidden border transition-colors duration-200 ${
+                    className={`relative shrink-0 overflow-hidden border bg-white/[0.07] transition-colors duration-200 ${
                       isSelected
-                        ? 'border-lime-400/40'
+                        ? 'border-lime-400/40 bg-white/[0.1]'
                         : isMasterAccount
                           ? 'border-lime-400/25 hover:border-lime-400/40'
-                          : 'border-white/10 hover:border-white/20'
+                          : 'border-white/15 hover:border-white/25'
                     }`}
                   >
                     <div
                       className={`pointer-events-none absolute inset-0 bg-center bg-no-repeat transition-opacity duration-200 ${
                         staffCard
-                          ? 'bg-[length:min(78%,12rem)] opacity-[0.22] brightness-0 invert'
-                          : 'bg-cover opacity-[0.22]'
-                      } ${isSelected ? (staffCard ? 'opacity-[0.3]' : 'opacity-[0.28]') : ''} ${
+                          ? 'bg-[length:min(78%,12rem)] opacity-[0.28] brightness-0 invert'
+                          : 'bg-cover opacity-[0.28]'
+                      } ${isSelected ? (staffCard ? 'opacity-[0.34]' : 'opacity-[0.32]') : ''} ${
                         user.disabledAt ? 'grayscale' : ''
                       }`}
                       style={{ backgroundImage: `url(${backdropSrc})` }}
@@ -466,8 +468,8 @@ const AdminUsersPage: React.FC = () => {
                     <div
                       className={`pointer-events-none absolute inset-0 ${
                         staffCard
-                          ? 'bg-[linear-gradient(to_bottom,rgba(0,0,0,0.55)_0%,rgba(0,0,0,0.72)_55%,rgba(0,0,0,0.88)_100%)]'
-                          : 'bg-[linear-gradient(to_bottom,rgba(0,0,0,0.65)_0%,rgba(0,0,0,0.82)_50%,rgba(0,0,0,0.92)_100%)]'
+                          ? 'bg-[linear-gradient(to_bottom,rgba(0,0,0,0.28)_0%,rgba(0,0,0,0.42)_55%,rgba(0,0,0,0.58)_100%)]'
+                          : 'bg-[linear-gradient(to_bottom,rgba(0,0,0,0.32)_0%,rgba(0,0,0,0.48)_50%,rgba(0,0,0,0.62)_100%)]'
                       }`}
                       aria-hidden
                     />

--- a/src/utils/mediaSession.ts
+++ b/src/utils/mediaSession.ts
@@ -1,0 +1,137 @@
+const DEFAULT_ARTWORK_PATH = '/icon-512.png';
+const ARTWORK_SIZES = ['96x96', '192x192', '512x512'] as const;
+
+export type NowPlayingParts = {
+  title: string;
+  artist: string;
+};
+
+/**
+ * Split "Artist - Title" style now-playing strings from BRLogic.
+ * Falls back to the full string as title when no separator is present.
+ */
+export function parseNowPlayingTrack(track: string, fallbackArtist = 'Radionudista'): NowPlayingParts {
+  const cleaned = track.replace(/\s+/g, ' ').trim();
+  if (!cleaned) {
+    return { title: 'En vivo', artist: fallbackArtist };
+  }
+
+  const separators = [' - ', ' – ', ' — ', ' | '];
+  for (const sep of separators) {
+    const idx = cleaned.indexOf(sep);
+    if (idx > 0 && idx < cleaned.length - sep.length) {
+      const artist = cleaned.slice(0, idx).trim();
+      const title = cleaned.slice(idx + sep.length).trim();
+      if (artist && title) {
+        return { title, artist };
+      }
+    }
+  }
+
+  return { title: cleaned, artist: fallbackArtist };
+}
+
+function toAbsoluteUrl(url: string): string | null {
+  try {
+    return new URL(url, typeof window !== 'undefined' ? window.location.origin : 'https://radionudista.com').href;
+  } catch {
+    return null;
+  }
+}
+
+function buildArtwork(src: string | null | undefined): MediaImage[] {
+  const absolute =
+    toAbsoluteUrl(src || DEFAULT_ARTWORK_PATH) ||
+    toAbsoluteUrl(DEFAULT_ARTWORK_PATH);
+
+  if (!absolute) return [];
+
+  return ARTWORK_SIZES.map((sizes) => ({
+    src: absolute,
+    sizes,
+    type: 'image/png',
+  }));
+}
+
+export function isMediaSessionSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'mediaSession' in navigator;
+}
+
+export function updateMediaSessionMetadata(options: {
+  title: string;
+  artist: string;
+  album?: string;
+  artworkUrl?: string | null;
+}): void {
+  if (!isMediaSessionSupported() || typeof MediaMetadata === 'undefined') return;
+
+  try {
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: options.title,
+      artist: options.artist,
+      album: options.album || 'Radionudista',
+      artwork: buildArtwork(options.artworkUrl),
+    });
+  } catch {
+    // Safari can throw if artwork URLs are invalid; ignore and keep playback.
+  }
+}
+
+export function setMediaSessionPlaybackState(
+  state: MediaSessionPlaybackState
+): void {
+  if (!isMediaSessionSupported()) return;
+  try {
+    navigator.mediaSession.playbackState = state;
+  } catch {
+    // Older Safari builds may not allow setting playbackState.
+  }
+}
+
+export function clearMediaSession(): void {
+  if (!isMediaSessionSupported()) return;
+  try {
+    navigator.mediaSession.metadata = null;
+    navigator.mediaSession.playbackState = 'none';
+  } catch {
+    // no-op
+  }
+}
+
+type MediaSessionActionHandlers = {
+  play: () => void;
+  pause: () => void;
+};
+
+/**
+ * Bind lock-screen / Control Center play/pause. Skip seek handlers on purpose
+ * (live stream UX is imperfect on iOS and out of scope).
+ */
+export function bindMediaSessionActionHandlers(
+  handlers: MediaSessionActionHandlers
+): () => void {
+  if (!isMediaSessionSupported()) return () => undefined;
+
+  const actions: MediaSessionAction[] = ['play', 'pause'];
+
+  for (const action of actions) {
+    try {
+      navigator.mediaSession.setActionHandler(action, () => {
+        if (action === 'play') handlers.play();
+        else handlers.pause();
+      });
+    } catch {
+      // Action may be unsupported on this browser.
+    }
+  }
+
+  return () => {
+    for (const action of actions) {
+      try {
+        navigator.mediaSession.setActionHandler(action, null);
+      } catch {
+        // no-op
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Push radio/program metadata (title, artist, artwork) to iOS Control Center / lock screen via Media Session.
- Keep BRLogic track polling while audio is playing in a backgrounded tab.
- Stretch the admin users left panel to full height and lighten user card backgrounds.

## Test plan
- [ ] Play the live radio in Safari on iOS, lock the phone, confirm title/artist/artwork appear
- [ ] Pause/play from the lock screen widget
- [ ] Open /admin/usuarios and confirm the left panel matches activity panel height and cards are more readable